### PR TITLE
GEMS file format support, experimental

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ set(SOURCES
   "src/FileFormats/ffmt_factory.cpp"
   "src/FileFormats/format_deflemask_dmp.cpp"
   "src/FileFormats/format_tfi.cpp"
+  "src/FileFormats/format_gems_pat.cpp"
   "src/FileFormats/format_vgm_import.cpp"
   "src/FileFormats/format_wohlstand_opn2.cpp"
   "src/formats_sup.cpp"

--- a/FMBankEdit.pro
+++ b/FMBankEdit.pro
@@ -101,6 +101,7 @@ SOURCES += \
     src/FileFormats/ffmt_factory.cpp \
     src/FileFormats/format_deflemask_dmp.cpp \
     src/FileFormats/format_tfi.cpp \
+    src/FileFormats/format_gems_pat.cpp \
     src/FileFormats/format_vgm_import.cpp \
     src/FileFormats/format_wohlstand_opn2.cpp \
     src/formats_sup.cpp \
@@ -131,6 +132,7 @@ HEADERS += \
     src/FileFormats/ffmt_factory.h \
     src/FileFormats/format_deflemask_dmp.h \
     src/FileFormats/format_tfi.h \
+    src/FileFormats/format_gems_pat.h \
     src/FileFormats/format_vgm_import.h \
     src/FileFormats/format_wohlstand_opn2.h \
     src/formats_sup.h \

--- a/Specifications/GEMS-file-specification.txt
+++ b/Specifications/GEMS-file-specification.txt
@@ -4,7 +4,7 @@
 
 ### Bank (BNK file)
 
-Bank name           - 64 bytes
+Bank name           - 100 bytes
 Instrument entries  - 128 * 80 bytes  see "Instrument"
 Footer              - ???
 

--- a/src/FileFormats/ffmt_enums.h
+++ b/src/FileFormats/ffmt_enums.h
@@ -24,9 +24,10 @@
  */
 enum BankFormats
 {
-    FORMAT_UNKNOWN = -1,
-    FORMAT_WOHLSTAND_OPN2 =   0,
-    FORMAT_VGM_IMPORTER =   1,
+    FORMAT_UNKNOWN        = -1,
+    FORMAT_WOHLSTAND_OPN2 = 0,
+    FORMAT_VGM_IMPORTER   = 1,
+    FORMAT_GEMS_BNK       = 2,
 
     FORMATS_END,
     FORMATS_BEGIN = FORMAT_WOHLSTAND_OPN2,
@@ -34,10 +35,11 @@ enum BankFormats
 
 enum InstFormats
 {
-    FORMAT_INST_UNKNOWN = -1,
-    FORMAT_INST_WOPN2   = 0,
-    FORMAT_INST_TFI_MM  = 1,
-    FORMAT_INST_DM_DMP  = 2,
+    FORMAT_INST_UNKNOWN  = -1,
+    FORMAT_INST_WOPN2    = 0,
+    FORMAT_INST_TFI_MM   = 1,
+    FORMAT_INST_DM_DMP   = 2,
+    FORMAT_INST_GEMS_PAT = 3,
 };
 
 enum class FormatCaps

--- a/src/FileFormats/ffmt_factory.cpp
+++ b/src/FileFormats/ffmt_factory.cpp
@@ -27,6 +27,7 @@
 #include "format_vgm_import.h"
 #include "format_tfi.h"
 #include "format_deflemask_dmp.h"
+#include "format_gems_pat.h"
 
 typedef std::unique_ptr<FmBankFormatBase> FmBankFormatBase_uptr;
 typedef std::list<FmBankFormatBase_uptr>  FmBankFormatsL;
@@ -55,6 +56,8 @@ void FmBankFormatFactory::registerAllFormats()
     registerBankFormat(new VGM_Importer());
     registerInstFormat(new TFI_MM());
     registerInstFormat(new DefleMask());
+    registerBankFormat(new GEMS_PAT());
+    registerInstFormat(new GEMS_PAT());
 }
 
 

--- a/src/FileFormats/format_gems_pat.cpp
+++ b/src/FileFormats/format_gems_pat.cpp
@@ -1,0 +1,223 @@
+/*
+ * OPN2 Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2018 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "format_gems_pat.h"
+#include "../common.h"
+
+#include <QSet>
+#include <QFileInfo>
+#include <QByteArray>
+#include <algorithm>
+
+
+bool GEMS_PAT::detect(const QString &filePath, char * /*magic*/)
+{
+    //By name extension
+    if(filePath.endsWith(".bnk", Qt::CaseInsensitive))
+        return true;
+
+    //By file size :-P
+    QFileInfo f(filePath);
+    if(f.size() == 10852)
+        return true;
+
+    return false;
+}
+
+FfmtErrCode GEMS_PAT::loadFile(QString filePath, FmBank &bank)
+{
+    uint8_t idata[10852];
+    QFile file(filePath);
+
+    if(!file.open(QIODevice::ReadOnly))
+        return FfmtErrCode::ERR_NOFILE;
+
+    if(file.size() != 10852)
+        return FfmtErrCode::ERR_BADFORMAT;
+
+    if(file.read(char_p(idata), 10852) != 10852)
+        return FfmtErrCode::ERR_BADFORMAT;
+
+    bank.reset(1, 0);
+
+    FmBank::MidiBank &bankMeta = bank.Banks_Melodic[0];
+
+    memset(bankMeta.name, 0, sizeof(bankMeta.name));
+    memcpy(bankMeta.name, idata, strnlen((const char *)idata, 32));
+
+    bankMeta.msb = 0;
+    bankMeta.lsb = 0;
+
+    for(unsigned i = 0; i < 128; ++i)
+    {
+        FmBank::Instrument &ins = bank.Ins_Melodic[i];
+        memset(&ins, 0, sizeof(ins));
+
+        FfmtErrCode err = loadMemInst(&idata[100 + i * 80], ins);
+        if(err != FfmtErrCode::ERR_OK)
+            ins.is_blank = true;
+    }
+
+
+    return FfmtErrCode::ERR_OK;
+}
+
+int GEMS_PAT::formatCaps() const
+{
+    return (int)FormatCaps::FORMAT_CAPS_OPEN;
+}
+
+QString GEMS_PAT::formatName() const
+{
+    return "GEMS bank";
+}
+
+QString GEMS_PAT::formatExtensionMask() const
+{
+    return "*.bnk";
+}
+
+BankFormats GEMS_PAT::formatId() const
+{
+    return BankFormats::FORMAT_GEMS_BNK;
+}
+
+bool GEMS_PAT::detectInst(const QString &filePath, char * /*magic*/)
+{
+    //By name extension
+    if(filePath.endsWith(".pat", Qt::CaseInsensitive))
+        return true;
+
+    //By file size :-P
+    QFileInfo f(filePath);
+    if(f.size() == 80)
+        return true;
+
+    return false;
+}
+
+FfmtErrCode GEMS_PAT::loadFileInst(QString filePath, FmBank::Instrument &inst, bool *isDrum)
+{
+    uint8_t idata[80];
+    QFile file(filePath);
+
+    if(!file.open(QIODevice::ReadOnly))
+        return FfmtErrCode::ERR_NOFILE;
+
+    if(file.size() != 80)
+        return FfmtErrCode::ERR_BADFORMAT;
+
+    if(file.read(char_p(idata), 80) != 80)
+        return FfmtErrCode::ERR_BADFORMAT;
+
+    FfmtErrCode err = loadMemInst(idata, inst);
+
+    file.close();
+
+    return err;
+}
+
+int GEMS_PAT::formatInstCaps() const
+{
+    return (int)FormatCaps::FORMAT_CAPS_OPEN;
+}
+
+QString GEMS_PAT::formatInstName() const
+{
+    return "GEMS instrument";
+}
+
+QString GEMS_PAT::formatInstExtensionMask() const
+{
+    return "*.pat";
+}
+
+InstFormats GEMS_PAT::formatInstId() const
+{
+    return FORMAT_INST_GEMS_PAT;
+}
+
+FfmtErrCode GEMS_PAT::loadMemInst(const uint8_t idata[80], FmBank::Instrument &inst)
+{
+    unsigned formatCode = (idata[0] << 8) | idata[1];
+    if(formatCode != 0)
+        return FfmtErrCode::ERR_BADFORMAT;
+
+    memset(&inst, 0, sizeof(FmBank::Instrument));
+
+    memcpy(inst.name, (const char *)&idata[2], strnlen((const char *)&idata[2], 28));
+
+    bool lfo_enabled = (idata[30] & (1 << 3)) != 0;
+    unsigned lfo_frequency = idata[30] & 7;
+    bool ch3_on = (idata[31] & (1 << 6)) != 0;
+
+    (void)lfo_enabled;
+    (void)lfo_frequency;
+    (void)ch3_on;
+
+    inst.feedback = (idata[32] >> 3) & 7;
+    inst.algorithm = idata[32] & 7;
+
+    bool left = idata[33] >> 7;
+    bool right = (idata[33] >> 6) & 1;
+
+    (void)left;
+    (void)right;
+
+    inst.am = (idata[33] >> 4) & 3;
+    inst.fm = idata[33] & 7;
+
+    for(unsigned i = 0; i < 4; ++i)
+    {
+        const unsigned opnum[] = {OPERATOR1_HR, OPERATOR3_HR, OPERATOR2_HR, OPERATOR4_HR};
+        const unsigned op = opnum[i];
+
+        inst.OP[op].fmult = idata[34 + i * 6] & 15;
+        inst.OP[op].detune = (idata[34 + i * 6] >> 4) & 7;
+        inst.OP[op].level = idata[35 + i * 6] & 127;
+        inst.OP[op].attack = idata[36 + i * 6] & 31;
+        inst.OP[op].ratescale = idata[36 + i * 6] >> 6;
+        inst.OP[op].decay1 = idata[37 + i * 6] & 31;
+        inst.OP[op].am_enable = idata[37 + i * 6] >> 7;
+        inst.OP[op].decay2 = idata[38 + i * 6] & 31;
+        inst.OP[op].release = idata[39 + i * 6] & 15;
+        inst.OP[op].sustain = (idata[39 + i * 6] >> 4) & 15;
+    }
+
+    for(unsigned i = 0; i < 4; ++i)
+    {
+        const unsigned opnum[] = {OPERATOR4_HR, OPERATOR3_HR, OPERATOR1_HR, OPERATOR2_HR};
+        const unsigned op = opnum[i];
+
+        unsigned ch3f = (idata[58 + i * 2] << 8) | idata[59 + i * 2];
+        (void)op;
+        (void)ch3f;
+    }
+
+    for(unsigned i = 0; i < 4; ++i)
+    {
+        const unsigned opnum[] = {OPERATOR1_HR, OPERATOR2_HR, OPERATOR3_HR, OPERATOR4_HR};
+        const unsigned op = opnum[i];
+
+        bool enable = (idata[66] & (1 << i)) != 0;
+        if(!enable)
+            inst.OP[op].level = 127;
+    }
+
+    return FfmtErrCode::ERR_OK;
+}

--- a/src/FileFormats/format_gems_pat.h
+++ b/src/FileFormats/format_gems_pat.h
@@ -1,0 +1,48 @@
+/*
+ * OPN2 Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2018 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FORMAT_GEMS_PAT_H
+#define FORMAT_GEMS_PAT_H
+
+#include "ffmt_base.h"
+
+/**
+ * @brief Reader and Writer of the TFI File Format file
+ */
+class GEMS_PAT final : public FmBankFormatBase
+{
+public:
+    bool        detect(const QString &filePath, char* magic) override;
+    FfmtErrCode loadFile(QString filePath, FmBank &bank) override;
+    int         formatCaps() const override;
+    QString     formatName() const override;
+    QString     formatExtensionMask() const override;
+    BankFormats formatId() const override;
+
+    bool        detectInst(const QString &filePath, char* magic) override;
+    FfmtErrCode loadFileInst(QString filePath, FmBank::Instrument &inst, bool *isDrum = 0) override;
+    int         formatInstCaps() const override;
+    QString     formatInstName() const override;
+    QString     formatInstExtensionMask() const override;
+    InstFormats formatInstId() const override;
+
+private:
+    FfmtErrCode loadMemInst(const uint8_t idata[80], FmBank::Instrument &inst);
+};
+
+#endif // FORMAT_GEMS_PAT_H


### PR DESCRIPTION
I implement read support for BNK and PAT files.

It's to test, as some instruments are sounding good and some not so much.
The values shown in both editors seem matching for most.

- no support of "CH3" stuff
- no support of LFO on/frequency (which GEMS takes as per-instrument)
- no support of disabling Left/Right
- I took GEMS "SLevel" as "Sustain", and GEMS "Sustain" as "Decay2". Check it
- I'm not sure about interpretation of Detune (GEMS has -3..+3) ~~which I converted to 0..7 range adding 3~~ using raw values of file
- conversions of operator orders to verify...
- to implement "Disable" flag on operator I chose to override level with 127