### PR TITLE
add basic register editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SOURCES
   "src/formats_sup.cpp"
   "src/importer.cpp"
   "src/latency.cpp"
+  "src/register_editor.cpp"
   "src/ins_names.cpp"
   "src/main.cpp"
   "src/opl/generator.cpp"
@@ -95,7 +96,8 @@ endif()
 set(UIS
   "src/bank_editor.ui"
   "src/formats_sup.ui"
-  "src/importer.ui")
+  "src/importer.ui"
+  "src/register_editor.ui")
 if(ENABLE_PLOTS)
   list(APPEND UIS
     "src/delay_analysis.ui")

--- a/FMBankEdit.pro
+++ b/FMBankEdit.pro
@@ -111,6 +111,7 @@ SOURCES += \
     src/formats_sup.cpp \
     src/importer.cpp \
     src/latency.cpp \
+    src/register_editor.cpp \
     src/ins_names.cpp \
     src/main.cpp \
     src/opl/generator.cpp \
@@ -146,6 +147,7 @@ HEADERS += \
     src/formats_sup.h \
     src/importer.h \
     src/latency.h \
+    src/register_editor.h \
     src/ins_names.h \
     src/main.h \
     src/opl/generator.h \
@@ -171,7 +173,8 @@ HEADERS += \
 FORMS += \
     src/bank_editor.ui \
     src/formats_sup.ui \
-    src/importer.ui
+    src/importer.ui \
+    src/register_editor.ui
 
 RESOURCES += \
     src/resources/resources.qrc

--- a/src/bank_editor.cpp
+++ b/src/bank_editor.cpp
@@ -36,6 +36,7 @@
 #if defined(ENABLE_PLOTS)
 #include "delay_analysis.h"
 #endif
+#include "register_editor.h"
 
 #include "FileFormats/ffmt_factory.h"
 
@@ -734,6 +735,28 @@ void BankEditor::on_actionDelayAnalysis_triggered()
     dialog.exec();
 }
 #endif
+
+void BankEditor::on_actionEditRegisters_triggered()
+{
+    FmBank::Instrument *inst = m_curInst;
+    if(!inst)
+    {
+        QMessageBox::information(this,
+                                 tr("Nothing to edit"),
+                                 tr("No selected instrument to edit. Please select an instrument first!"));
+        return;
+    }
+
+    FmBank::Instrument workInst = *inst;
+    workInst.is_blank = false;
+
+    RegisterEditorDialog dialog(&workInst, this);
+    if(dialog.exec() == QDialog::Accepted)
+    {
+        *m_curInst = workInst;
+        flushInstrument();
+    }
+}
 
 void BankEditor::on_actionFormatsSup_triggered()
 {

--- a/src/bank_editor.h
+++ b/src/bank_editor.h
@@ -341,6 +341,11 @@ private slots:
 #endif
 
     /**
+     * @brief Run the register editor
+     */
+    void on_actionEditRegisters_triggered();
+
+    /**
      * @brief Show all supported formats list
      */
     void on_actionFormatsSup_triggered();

--- a/src/bank_editor.ui
+++ b/src/bank_editor.ui
@@ -3512,6 +3512,7 @@ Available from 0 to 127</string>
     <addaction name="separator"/>
     <addaction name="actionReset_current_instrument"/>
     <addaction name="separator"/>
+    <addaction name="actionEditRegisters"/>
     <addaction name="actionReMeasureOne"/>
     <addaction name="actionReMeasure"/>
     <addaction name="actionDelayAnalysis"/>
@@ -3734,6 +3735,11 @@ Available from 0 to 127</string>
   <action name="actionSaveAs">
    <property name="text">
     <string>Save bank as...</string>
+   </property>
+  </action>
+  <action name="actionEditRegisters">
+   <property name="text">
+    <string>Edit registers</string>
    </property>
   </action>
  </widget>

--- a/src/register_editor.cpp
+++ b/src/register_editor.cpp
@@ -1,0 +1,205 @@
+/*
+ * OPN2 Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2018 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "register_editor.h"
+#include "ui_register_editor.h"
+#include <QRegExpValidator>
+#include <QDebug>
+#include <algorithm>
+
+class ByteValidator : public QValidator
+{
+public:
+    explicit ByteValidator(QLineEdit **widgets, unsigned index, unsigned count);
+    void fixup(QString &input) const override;
+    State validate(QString &input, int &pos) const override;
+private:
+    QLineEdit **m_widgets = nullptr;
+    unsigned m_index = 0;
+    unsigned m_count = 0;
+};
+
+RegisterEditorDialog::RegisterEditorDialog(FmBank::Instrument *ins, QWidget *parent)
+    : QDialog(parent),
+      m_ui(new Ui::RegisterEditorDialog),
+      m_ins(ins)
+{
+    Ui::RegisterEditorDialog *ui = m_ui.get();
+    ui->setupUi(this);
+
+    QLineEdit *regWidgets[RegisterCount] = {
+        ui->reg3xOp1, ui->reg3xOp2, ui->reg3xOp3, ui->reg3xOp4,
+        ui->reg4xOp1, ui->reg4xOp2, ui->reg4xOp3, ui->reg4xOp4,
+        ui->reg5xOp1, ui->reg5xOp2, ui->reg5xOp3, ui->reg5xOp4,
+        ui->reg6xOp1, ui->reg6xOp2, ui->reg6xOp3, ui->reg6xOp4,
+        ui->reg7xOp1, ui->reg7xOp2, ui->reg7xOp3, ui->reg7xOp4,
+        ui->reg8xOp1, ui->reg8xOp2, ui->reg8xOp3, ui->reg8xOp4,
+        ui->reg9xOp1, ui->reg9xOp2, ui->reg9xOp3, ui->reg9xOp4,
+        ui->regB0,    ui->regB4,
+    };
+
+    std::copy(regWidgets, regWidgets + RegisterCount, m_regWidgets);
+
+    for(unsigned i = 0; i < RegisterCount; ++i)
+    {
+        QLineEdit *w = regWidgets[i];
+        w->setValidator(new ByteValidator(m_regWidgets, i, RegisterCount));
+    }
+    loadInstrument();
+
+    connect(this, SIGNAL(accepted()), this, SLOT(saveInstrument()));
+}
+
+RegisterEditorDialog::~RegisterEditorDialog()
+{
+}
+
+static uint8_t getWidgetValue(QLineEdit *w)
+{
+    return (uint8_t)w->text().toUInt(nullptr, 16);
+}
+
+static void setWidgetValue(QLineEdit *w, uint8_t v)
+{
+    char text[3];
+    snprintf(text, sizeof(text), "%02X", v);
+    w->setText(text);
+}
+
+void RegisterEditorDialog::loadInstrument()
+{
+    const FmBank::Instrument &ins = *m_ins;
+    QLineEdit **widgets = m_regWidgets;
+
+    for(unsigned i = 0; i < 4; ++i)
+    {
+        const unsigned opnum[] = {OPERATOR1_HR, OPERATOR3_HR, OPERATOR2_HR, OPERATOR4_HR};
+        const unsigned op = opnum[i];
+
+        uint8_t values[7] = {
+            ins.getRegDUMUL(op),
+            ins.getRegLevel(op),
+            ins.getRegRSAt(op),
+            ins.getRegAMD1(op),
+            ins.getRegD2(op),
+            ins.getRegSysRel(op),
+            ins.getRegSsgEg(op),
+        };
+
+        for (unsigned j = 0; j < 7; ++j)
+        {
+            QLineEdit *w = widgets[4 * j + i];
+            setWidgetValue(w, values[j]);
+        }
+    }
+
+    setWidgetValue(widgets[28], ins.getRegFbAlg());
+    setWidgetValue(widgets[29], ins.getRegLfoSens());
+}
+
+void RegisterEditorDialog::saveInstrument()
+{
+    FmBank::Instrument &ins = *m_ins;
+    QLineEdit **widgets = m_regWidgets;
+
+    for(unsigned i = 0; i < 4; ++i)
+    {
+        const unsigned opnum[] = {OPERATOR1_HR, OPERATOR3_HR, OPERATOR2_HR, OPERATOR4_HR};
+        const unsigned op = opnum[i];
+
+        for (unsigned j = 0; j < 7; ++j)
+        {
+            QLineEdit *w = widgets[4 * j + i];
+            uint8_t value = getWidgetValue(w);
+            switch(j)
+            {
+            case 0: ins.setRegDUMUL(op, value); break;
+            case 1: ins.setRegLevel(op, value); break;
+            case 2: ins.setRegRSAt(op, value); break;
+            case 3: ins.setRegAMD1(op, value); break;
+            case 4: ins.setRegD2(op, value); break;
+            case 5: ins.setRegSysRel(op, value); break;
+            case 6: ins.setRegSsgEg(op, value); break;
+            }
+        }
+    }
+
+    ins.setRegFbAlg(getWidgetValue(widgets[28]));
+    ins.setRegLfoSens(getWidgetValue(widgets[29]));
+}
+
+void RegisterEditorDialog::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::LanguageChange)
+        onLanguageChanged();
+    QDialog::changeEvent(event);
+}
+
+void RegisterEditorDialog::onLanguageChanged()
+{
+    m_ui->retranslateUi(this);
+}
+
+ByteValidator::ByteValidator(QLineEdit **widgets, unsigned index, unsigned count)
+    : QValidator(widgets[index]),
+      m_widgets(widgets), m_index(index), m_count(count)
+{
+}
+
+void ByteValidator::fixup(QString &input) const
+{
+    for(QChar &ch : input)
+        ch = ch.toUpper();
+}
+
+QValidator::State ByteValidator::validate(QString &input, int &pos) const
+{
+    QString result;
+    unsigned length = input.size();
+    result.reserve(length);
+
+    // convert to uppercase discarding junk characters
+    for (unsigned i = 0; i < length; ++i)
+    {
+        QChar ch = input[i].toUpper();
+        if((ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F'))
+            result.push_back(ch);
+        else if((ch >= 'a' && ch <= 'f'))
+            result.push_back(ch.toUpper());
+        else if ((unsigned)pos > i)
+            --pos;
+    }
+
+    // take 2 beggining characters at most
+    length = result.size();
+    input = result.left(std::min(2u, length));
+
+    // pass rest to next editor
+    QString rest = result.mid(std::min(2u, length));
+    if(!rest.isEmpty())
+    {
+        if(m_index + 1 < m_count)
+        {
+            QLineEdit *next = m_widgets[m_index + 1];
+            QMetaObject::invokeMethod(next, "setText", Qt::QueuedConnection, Q_ARG(QString, rest));
+            QMetaObject::invokeMethod(next, "setFocus", Qt::QueuedConnection);
+        }
+    }
+
+    return QValidator::Acceptable;
+}

--- a/src/register_editor.h
+++ b/src/register_editor.h
@@ -1,0 +1,53 @@
+/*
+ * OPN2 Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2018 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "bank.h"
+#include <QDialog>
+#include <memory>
+
+namespace Ui { class RegisterEditorDialog; }
+class QLineEdit;
+
+class RegisterEditorDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit RegisterEditorDialog(FmBank::Instrument *ins, QWidget *parent = nullptr);
+    ~RegisterEditorDialog();
+
+private:
+    void loadInstrument();
+private slots:
+    void saveInstrument();
+
+protected:
+    void changeEvent(QEvent *event) override;
+
+private:
+    /**
+     * @brief Updates the text to display after a language change
+     */
+    void onLanguageChanged();
+
+private:
+    const std::unique_ptr<Ui::RegisterEditorDialog> m_ui;
+    FmBank::Instrument *m_ins = nullptr;
+    enum { RegisterCount = 30 };
+    QLineEdit *m_regWidgets[RegisterCount] = {};
+};

--- a/src/register_editor.ui
+++ b/src/register_editor.ui
@@ -1,0 +1,849 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>RegisterEditorDialog</class>
+ <widget class="QDialog" name="RegisterEditorDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>244</width>
+    <height>359</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Register Editor</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>$30</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="reg3xOp1">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLineEdit" name="reg3xOp2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QLineEdit" name="reg3xOp3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="QLineEdit" name="reg3xOp4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>$40</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="reg4xOp1">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QLineEdit" name="reg4xOp2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QLineEdit" name="reg4xOp3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="QLineEdit" name="reg4xOp4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>$50</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="reg5xOp1">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QLineEdit" name="reg5xOp2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="QLineEdit" name="reg5xOp3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="4">
+      <widget class="QLineEdit" name="reg5xOp4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>$60</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="reg6xOp1">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QLineEdit" name="reg6xOp2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="QLineEdit" name="reg6xOp3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="4">
+      <widget class="QLineEdit" name="reg6xOp4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>$70</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLineEdit" name="reg7xOp1">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="2">
+      <widget class="QLineEdit" name="reg7xOp2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="3">
+      <widget class="QLineEdit" name="reg7xOp3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="4">
+      <widget class="QLineEdit" name="reg7xOp4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>$80</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLineEdit" name="reg8xOp1">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
+      <widget class="QLineEdit" name="reg8xOp2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="3">
+      <widget class="QLineEdit" name="reg8xOp3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="4">
+      <widget class="QLineEdit" name="reg8xOp4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>$90</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QLineEdit" name="reg9xOp1">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="2">
+      <widget class="QLineEdit" name="reg9xOp2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="3">
+      <widget class="QLineEdit" name="reg9xOp3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="4">
+      <widget class="QLineEdit" name="reg9xOp4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label_8">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>$B0</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="regB0">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_9">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>$B4</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="regB4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>FF</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Maximum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>RegisterEditorDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>RegisterEditorDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/translations/opn2bankeditor_fr_FR.ts
+++ b/src/translations/opn2bankeditor_fr_FR.ts
@@ -233,7 +233,7 @@
     </message>
     <message>
         <location filename="../bank_editor.ui" line="2823"/>
-        <location filename="../bank_editor.cpp" line="566"/>
+        <location filename="../bank_editor.cpp" line="567"/>
         <source>&lt;Untitled&gt;</source>
         <translation>&lt;Sans titre&gt;</translation>
     </message>
@@ -586,37 +586,37 @@ de la deuxième voix</translation>
         <translation type="vanished">Coller une voix</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3533"/>
+        <location filename="../bank_editor.ui" line="3534"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3537"/>
+        <location filename="../bank_editor.ui" line="3538"/>
         <source>Choose chip emulator</source>
         <translation>Choisir l&apos;émulateur de circuit</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3555"/>
+        <location filename="../bank_editor.ui" line="3556"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3736"/>
+        <location filename="../bank_editor.ui" line="3737"/>
         <source>Save bank as...</source>
         <translation>Enregistrer la banque sous...</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3571"/>
+        <location filename="../bank_editor.ui" line="3572"/>
         <source>Exit</source>
         <translation>Quitter</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3579"/>
+        <location filename="../bank_editor.ui" line="3580"/>
         <source>About</source>
         <translation>À propos</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3584"/>
+        <location filename="../bank_editor.ui" line="3585"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
@@ -629,32 +629,32 @@ de la deuxième voix</translation>
         <translation type="vanished">Coller l&apos;instrument</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3605"/>
+        <location filename="../bank_editor.ui" line="3606"/>
         <source>Reset current instrument</source>
         <translation>Réinitialiser l&apos;instrument courant</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3613"/>
+        <location filename="../bank_editor.ui" line="3614"/>
         <source>Import instruments...</source>
         <translation>Importer les instruments...</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3618"/>
+        <location filename="../bank_editor.ui" line="3619"/>
         <source>Add instrument</source>
         <translation>Ajouter un instrument</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3623"/>
+        <location filename="../bank_editor.ui" line="3624"/>
         <source>Delete current instrument</source>
         <translation>Supprimer l&apos;instrument courant</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3628"/>
+        <location filename="../bank_editor.ui" line="3629"/>
         <source>Save current instrument as...</source>
         <translation>Enregister l&apos;instrument courant sous...</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3661"/>
+        <location filename="../bank_editor.ui" line="3662"/>
         <source>United view of all banks</source>
         <translation>Vue unifiée de toutes les banques</translation>
     </message>
@@ -663,17 +663,17 @@ de la deuxième voix</translation>
         <translation type="vanished">Afficher les instruments sans les séparer en banques de 128 instruments</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3633"/>
+        <location filename="../bank_editor.ui" line="3634"/>
         <source>Add bank</source>
         <translation>Ajouter une banque</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3648"/>
+        <location filename="../bank_editor.ui" line="3649"/>
         <source>Delete bank</source>
         <translation>Supprimer la banque</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3638"/>
+        <location filename="../bank_editor.ui" line="3639"/>
         <source>Clone bank</source>
         <translation>Cloner la banque</translation>
     </message>
@@ -1243,52 +1243,57 @@ de la deuxième voix</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3589"/>
+        <location filename="../bank_editor.ui" line="3590"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3597"/>
+        <location filename="../bank_editor.ui" line="3598"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3653"/>
+        <location filename="../bank_editor.ui" line="3654"/>
         <source>Clear instrument</source>
         <translation>Effacer l&apos;instrument</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3664"/>
+        <location filename="../bank_editor.ui" line="3665"/>
         <source>Show all instruments without separating them into 128-instrument banks</source>
         <translation>Afficher les instruments sans les séparer en banques de 128 instruments</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3682"/>
+        <location filename="../bank_editor.ui" line="3683"/>
         <source>Nuked OPN2 (very accurate)</source>
         <translation>Nuked OPN2 (très précis)</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3690"/>
+        <location filename="../bank_editor.ui" line="3691"/>
         <source>Mame YM2612</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3698"/>
+        <location filename="../bank_editor.ui" line="3699"/>
         <source>GENS 2.10 (for slow CPUs, legacy)</source>
         <translation>GENS 2.10 (pour processeurs lents, obsolète)</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3716"/>
+        <location filename="../bank_editor.ui" line="3717"/>
         <source>Genesis Plus GX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3643"/>
+        <location filename="../bank_editor.ui" line="3742"/>
+        <source>Edit registers</source>
+        <translation>Éditer les registres</translation>
+    </message>
+    <message>
+        <location filename="../bank_editor.ui" line="3644"/>
         <source>Clear bank</source>
         <translation>Effacer la banque</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3669"/>
+        <location filename="../bank_editor.ui" line="3670"/>
         <source>Supported formats...</source>
         <translation>Formats compatibles...</translation>
     </message>
@@ -1313,17 +1318,17 @@ de la deuxième voix</translation>
         <translation type="vanished">Coller la voix 2 sur la voix 2</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3674"/>
+        <location filename="../bank_editor.ui" line="3675"/>
         <source>Re-Calculate all sounding delays</source>
         <translation>Recalculer tous les délais sonores</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3703"/>
+        <location filename="../bank_editor.ui" line="3704"/>
         <source>Run emulators benchmark</source>
         <translation>Évaluer la performance des émulateurs</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3563"/>
+        <location filename="../bank_editor.ui" line="3564"/>
         <source>Save bank...</source>
         <translation>Enregistrer la banque...</translation>
     </message>
@@ -1332,44 +1337,44 @@ de la deuxième voix</translation>
         <translation type="vanished">Interfaçage avec un circuit OPL3 réel</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3708"/>
+        <location filename="../bank_editor.ui" line="3709"/>
         <source>Audio &amp;latency...</source>
         <translation>&amp;Latence audio...</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3731"/>
+        <location filename="../bank_editor.ui" line="3732"/>
         <source>System default</source>
         <translation>Par défaut du système</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3721"/>
+        <location filename="../bank_editor.ui" line="3722"/>
         <source>Re-Calculate sounding delays of instrument</source>
         <translation>Recalculer les délais sonores de l&apos;instrument</translation>
     </message>
     <message>
-        <location filename="../bank_editor.ui" line="3726"/>
+        <location filename="../bank_editor.ui" line="3727"/>
         <source>Run delay analysis</source>
         <translation>Lancer l&apos;analyse des délais</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="356"/>
-        <location filename="../bank_editor.cpp" line="401"/>
-        <location filename="../bank_editor.cpp" line="441"/>
+        <location filename="../bank_editor.cpp" line="357"/>
+        <location filename="../bank_editor.cpp" line="402"/>
+        <location filename="../bank_editor.cpp" line="442"/>
         <source>bad file format</source>
         <translation>mauvais format de fichier</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="359"/>
+        <location filename="../bank_editor.cpp" line="360"/>
         <source>can&apos;t open file</source>
         <translation>impossible d&apos;ouvrir le fichier</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="362"/>
+        <location filename="../bank_editor.cpp" line="363"/>
         <source>reading of this format is not implemented yet</source>
         <translation>la lecture de ce format n&apos;est pas encore implémentée</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="365"/>
+        <location filename="../bank_editor.cpp" line="366"/>
         <source>unsupported file format</source>
         <translation>format de fichier non géré</translation>
     </message>
@@ -1378,7 +1383,7 @@ de la deuxième voix</translation>
         <translation type="obsolete">une erreur inconnue s&apos;est produite</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="380"/>
+        <location filename="../bank_editor.cpp" line="381"/>
         <source>Bank &apos;%1&apos; has been loaded!</source>
         <translation>La banque &apos;%1&apos; a été chargée !</translation>
     </message>
@@ -1419,74 +1424,74 @@ Do you want to continue file saving?</source>
 Voulez vous poursuivre l&apos;enregistrement ?</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="404"/>
-        <location filename="../bank_editor.cpp" line="444"/>
+        <location filename="../bank_editor.cpp" line="405"/>
+        <location filename="../bank_editor.cpp" line="445"/>
         <source>can&apos;t open file for write</source>
         <translation>impossible d&apos;ouvrir le fichier en écriture</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="407"/>
-        <location filename="../bank_editor.cpp" line="447"/>
+        <location filename="../bank_editor.cpp" line="408"/>
+        <location filename="../bank_editor.cpp" line="448"/>
         <source>writing into this format is not implemented yet</source>
         <translation>l&apos;écriture de ce format n&apos;est pas encore implémentée</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="410"/>
-        <location filename="../bank_editor.cpp" line="450"/>
+        <location filename="../bank_editor.cpp" line="411"/>
+        <location filename="../bank_editor.cpp" line="451"/>
         <source>unsupported file format, please define file name extension to choice target file format</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="426"/>
+        <location filename="../bank_editor.cpp" line="427"/>
         <source>Bank file &apos;%1&apos; has been saved!</source>
         <translation>Le fichier banque &apos;%1&apos; a été enregistré !</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="463"/>
+        <location filename="../bank_editor.cpp" line="464"/>
         <source>Instrument file &apos;%1&apos; has been saved!</source>
         <translation>Le fichier instrument &apos;%1&apos; a été enregistré !</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="509"/>
+        <location filename="../bank_editor.cpp" line="510"/>
         <source>Nothing to save</source>
         <translation>Rien à engistrer</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="510"/>
+        <location filename="../bank_editor.cpp" line="511"/>
         <source>No selected instrument to save. Please select an instrument first!</source>
         <translation>Aucun instrument à enregistrer n&apos;est sélectionné. Veuillez d&apos;abord sélectionner un instrument !</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="527"/>
+        <location filename="../bank_editor.cpp" line="528"/>
         <source>File is not saved</source>
         <translation>Fichier non enregistré</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="527"/>
+        <location filename="../bank_editor.cpp" line="528"/>
         <source>File is modified and not saved. Do you want to save it?</source>
         <translation>Le fichier a des modifications non enregistrées. Voulez vous sauvegarder ?</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="632"/>
+        <location filename="../bank_editor.cpp" line="633"/>
         <source>Reset instrument to initial state</source>
         <translation>Remise à zéro de l&apos;instrument</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="633"/>
+        <location filename="../bank_editor.cpp" line="634"/>
         <source>This instrument will be reset to initial state (since this file was loaded or saved).
 Do you wish to continue?</source>
         <translation>Cet instrument sera remis à l&apos;état initial (tel qu&apos;au dernier chargement ou enregistrement du fichier).
 Voulez-vous continuer ?</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="668"/>
-        <location filename="../bank_editor.cpp" line="719"/>
+        <location filename="../bank_editor.cpp" line="669"/>
+        <location filename="../bank_editor.cpp" line="720"/>
         <source>Nothing to measure</source>
         <translation>Rien à mesurer</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="669"/>
-        <location filename="../bank_editor.cpp" line="720"/>
+        <location filename="../bank_editor.cpp" line="670"/>
+        <location filename="../bank_editor.cpp" line="721"/>
         <source>No selected instrument to measure. Please select an instrument first!</source>
         <translation>Aucun instrument à mesurer n&apos;est sélectionné. Veuillez d&apos;abord sélectionner un instrument !</translation>
     </message>
@@ -1497,67 +1502,67 @@ Voulez-vous continuer ?</translation>
 </translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="843"/>
-        <location filename="../bank_editor.cpp" line="858"/>
+        <location filename="../bank_editor.cpp" line="866"/>
+        <location filename="../bank_editor.cpp" line="881"/>
         <source>Delays on: %1, off: %2</source>
         <translation>Délais on: %1, off: %2</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1341"/>
-        <location filename="../bank_editor.cpp" line="1379"/>
-        <location filename="../bank_editor.cpp" line="1468"/>
+        <location filename="../bank_editor.cpp" line="1364"/>
+        <location filename="../bank_editor.cpp" line="1402"/>
+        <location filename="../bank_editor.cpp" line="1491"/>
         <source>United bank mode is turned on. Disable it to be able add or remove banks.</source>
         <translation>Le mode unifié est activé. Désactivez le pour pouvoir ajouter ou supprimer des banques.</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1426"/>
+        <location filename="../bank_editor.cpp" line="1449"/>
         <source>United bank mode is turned on. Disable it to be able clear banks.</source>
         <translation>Le mode unifié est activé. Désactivez le pour pouvoir effacer des banques.</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1431"/>
+        <location filename="../bank_editor.cpp" line="1454"/>
         <source>128-instrument bank erasure</source>
         <translation>Effacement de banque à 128 instruments</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1432"/>
+        <location filename="../bank_editor.cpp" line="1455"/>
         <source>All instruments in this bank will be cleared. Do you want continue erasure?</source>
         <translation>Tous les instruments de cette banque seront effacés. Confirmer la suppression ?</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="647"/>
+        <location filename="../bank_editor.cpp" line="648"/>
         <source>Are you sure?</source>
         <translation>Êtes-vous sûr ?</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="368"/>
-        <location filename="../bank_editor.cpp" line="413"/>
-        <location filename="../bank_editor.cpp" line="453"/>
+        <location filename="../bank_editor.cpp" line="369"/>
+        <location filename="../bank_editor.cpp" line="414"/>
+        <location filename="../bank_editor.cpp" line="454"/>
         <source>unknown error occurred</source>
         <translation>une erreur inconnue s&apos;est produite</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="648"/>
+        <location filename="../bank_editor.cpp" line="649"/>
         <source>All sounding delays measures will be re-calculated. This operation may take a while. Do you want to continue? You may cancel operation in any moment.</source>
         <translation>Toutes les mesures de délais sonores seront recalculées. Cette opération peut prendre du temps. Voulez-vous continuer ? Cette opération peut être interrompue à tout moment.</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="655"/>
+        <location filename="../bank_editor.cpp" line="656"/>
         <source>Sounding delays calculation has been completed!</source>
         <translation>Le calcul des délais sonores est terminé !</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="657"/>
+        <location filename="../bank_editor.cpp" line="658"/>
         <source>Sounding delays calculation was canceled!</source>
         <translation>Le calcul des délais sonores a été annulé !</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="698"/>
+        <location filename="../bank_editor.cpp" line="699"/>
         <source>Benchmark result</source>
         <translation>Compte rendu de la performance</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="699"/>
+        <location filename="../bank_editor.cpp" line="700"/>
         <source>Result of emulators benchmark based on &apos;%1&apos; instrument:
 
 %2</source>
@@ -1566,19 +1571,29 @@ Voulez-vous continuer ?</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="707"/>
-        <location filename="../bank_editor.cpp" line="1266"/>
-        <location filename="../bank_editor.cpp" line="1282"/>
+        <location filename="../bank_editor.cpp" line="708"/>
+        <location filename="../bank_editor.cpp" line="1289"/>
+        <location filename="../bank_editor.cpp" line="1305"/>
         <source>Instrument is not selected</source>
         <translation>Aucun instrument n&apos;est sélectionné</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="708"/>
+        <location filename="../bank_editor.cpp" line="709"/>
         <source>Please select any instrument to begin the benchmark of emulators!</source>
         <translation>Veuillez selectionner un instrument pour évaluer la performance des émulateurs !</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="747"/>
+        <location filename="../bank_editor.cpp" line="745"/>
+        <source>Nothing to edit</source>
+        <translation>Rien à éditer</translation>
+    </message>
+    <message>
+        <location filename="../bank_editor.cpp" line="746"/>
+        <source>No selected instrument to edit. Please select an instrument first!</source>
+        <translation>Aucun instrument à éditer n&apos;est sélectionné. Veuillez d&apos;abord sélectionner un instrument !</translation>
+    </message>
+    <message>
+        <location filename="../bank_editor.cpp" line="770"/>
         <source>About bank editor</source>
         <translation>À propos de l&apos;éditeur de banques</translation>
     </message>
@@ -1605,7 +1620,7 @@ Source code disponible sur GitHub :
         <translation type="vanished">Banque %1</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="748"/>
+        <location filename="../bank_editor.cpp" line="771"/>
         <source>FM Bank Editor for Yamaha OPN2 chip, Version %1
 
 %2
@@ -1624,88 +1639,88 @@ Source code disponible sur GitHub :
 %3</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1071"/>
+        <location filename="../bank_editor.cpp" line="1094"/>
         <source>Change name of bank</source>
         <translation>Renommer la banque</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1071"/>
+        <location filename="../bank_editor.cpp" line="1094"/>
         <source>Please type name of current bank (32 characters max):</source>
         <translation>Veuillez saisir le nom de la banque actuelle (32 caractères maxi) :</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1267"/>
+        <location filename="../bank_editor.cpp" line="1290"/>
         <source>Select instrument to clear please</source>
         <translation>Veuillez sélectionner l&apos;instrument à effacer</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1283"/>
+        <location filename="../bank_editor.cpp" line="1306"/>
         <source>Select instrument to remove please</source>
         <translation>Veuillez sélectionner l&apos;instrument à supprimer</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1288"/>
+        <location filename="../bank_editor.cpp" line="1311"/>
         <source>Single instrument deletion</source>
         <translation>Suppression d&apos;un seul instrument</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1289"/>
+        <location filename="../bank_editor.cpp" line="1312"/>
         <source>Deletion of instrument will cause offset of all next instrument indexes. Suggested to use &apos;Clear instrument&apos; action instead. Do you want continue deletion?</source>
         <translation>Supprimer cet instrument causera un décalage des indices d&apos;instruments suivants. Il est plutôt conseillé d&apos;&quot;Effacer l&apos;instrument&quot;. Supprimer malgré tout ?</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1340"/>
+        <location filename="../bank_editor.cpp" line="1363"/>
         <source>Add bank error</source>
         <translation>Erreur d&apos;ajout de banque</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1378"/>
+        <location filename="../bank_editor.cpp" line="1401"/>
         <source>Clone bank error</source>
         <translation>Erreur de clonage de banque</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1425"/>
+        <location filename="../bank_editor.cpp" line="1448"/>
         <source>Clear bank error</source>
         <translation>Erreur d&apos;effacement de banque</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1467"/>
-        <location filename="../bank_editor.cpp" line="1476"/>
+        <location filename="../bank_editor.cpp" line="1490"/>
+        <location filename="../bank_editor.cpp" line="1499"/>
         <source>Delete bank error</source>
         <translation>Erreur de suppression de banque</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1477"/>
+        <location filename="../bank_editor.cpp" line="1500"/>
         <source>Removing of last bank is not allowed!</source>
         <translation>Impossible de supprimer la dernière banque !</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1482"/>
+        <location filename="../bank_editor.cpp" line="1505"/>
         <source>128-instrument bank deletion</source>
         <translation>Suppression d&apos;une banque à 128 instruments</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1483"/>
+        <location filename="../bank_editor.cpp" line="1506"/>
         <source>Deletion of bank will cause offset of all next bank indexes. Suggested to use &apos;Clear bank&apos; action instead. Do you want continue deletion?</source>
         <translation>Supprimer cette banque causera un décalage des indices de banques suivantes. Il est plutôt conseillé d&apos;&quot;Effacer la banque&quot;. Supprimer malgré tout ?</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1534"/>
+        <location filename="../bank_editor.cpp" line="1557"/>
         <source>Virtual port</source>
         <translation>Port virtuel</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1553"/>
+        <location filename="../bank_editor.cpp" line="1576"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1594"/>
+        <location filename="../bank_editor.cpp" line="1617"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../bank_editor.cpp" line="1595"/>
+        <location filename="../bank_editor.cpp" line="1618"/>
         <source>Cannot open the MIDI port.</source>
         <translation>Impossible d&apos;ouvrir le port MIDI.</translation>
     </message>
@@ -1985,6 +2000,93 @@ Si des problèmes audio se produisent, réassignez à ce paramètre à une valeu
         <translation type="vanished">Canaux :
 2-op : %1, Ps-4op : %2
 4-op : %3</translation>
+    </message>
+</context>
+<context>
+    <name>RegisterEditorDialog</name>
+    <message>
+        <location filename="../register_editor.ui" line="14"/>
+        <source>Register Editor</source>
+        <translation>Éditeur de Registres</translation>
+    </message>
+    <message>
+        <location filename="../register_editor.ui" line="22"/>
+        <source>$30</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../register_editor.ui" line="41"/>
+        <location filename="../register_editor.ui" line="63"/>
+        <location filename="../register_editor.ui" line="85"/>
+        <location filename="../register_editor.ui" line="107"/>
+        <location filename="../register_editor.ui" line="136"/>
+        <location filename="../register_editor.ui" line="158"/>
+        <location filename="../register_editor.ui" line="180"/>
+        <location filename="../register_editor.ui" line="202"/>
+        <location filename="../register_editor.ui" line="231"/>
+        <location filename="../register_editor.ui" line="253"/>
+        <location filename="../register_editor.ui" line="275"/>
+        <location filename="../register_editor.ui" line="297"/>
+        <location filename="../register_editor.ui" line="326"/>
+        <location filename="../register_editor.ui" line="348"/>
+        <location filename="../register_editor.ui" line="370"/>
+        <location filename="../register_editor.ui" line="392"/>
+        <location filename="../register_editor.ui" line="421"/>
+        <location filename="../register_editor.ui" line="443"/>
+        <location filename="../register_editor.ui" line="465"/>
+        <location filename="../register_editor.ui" line="487"/>
+        <location filename="../register_editor.ui" line="516"/>
+        <location filename="../register_editor.ui" line="538"/>
+        <location filename="../register_editor.ui" line="560"/>
+        <location filename="../register_editor.ui" line="582"/>
+        <location filename="../register_editor.ui" line="611"/>
+        <location filename="../register_editor.ui" line="633"/>
+        <location filename="../register_editor.ui" line="655"/>
+        <location filename="../register_editor.ui" line="677"/>
+        <location filename="../register_editor.ui" line="716"/>
+        <location filename="../register_editor.ui" line="764"/>
+        <source>FF</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../register_editor.ui" line="117"/>
+        <source>$40</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../register_editor.ui" line="212"/>
+        <source>$50</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../register_editor.ui" line="307"/>
+        <source>$60</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../register_editor.ui" line="402"/>
+        <source>$70</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../register_editor.ui" line="497"/>
+        <source>$80</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../register_editor.ui" line="592"/>
+        <source>$90</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../register_editor.ui" line="697"/>
+        <source>$B0</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../register_editor.ui" line="745"/>
+        <source>$B4</source>
+        <translation></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Adds a register editor as dialog.

This allows to edit by hand and also copy-paste into a form of line edits which are chained.
It will remove all crap like '$' and ',' so it can take the bytes from various hex dumps and asm files.