### PR TITLE
display blank entries in gray color

### DIFF
--- a/src/bank_editor.cpp
+++ b/src/bank_editor.cpp
@@ -83,6 +83,8 @@ BankEditor::BankEditor(QWidget *parent) :
     this->setWindowIcon(makeWindowIcon());
     ui->version->setText(QString("%1, v.%2").arg(PROGRAM_NAME).arg(VERSION));
     m_recentMelodicNote = ui->noteToTest->value();
+    m_bank.Ins_Melodic_box.fill(FmBank::blankInst());
+    m_bank.Ins_Percussion_box.fill(FmBank::blankInst());
     setMelodic();
     connect(ui->melodic,    SIGNAL(clicked(bool)),  this,   SLOT(setMelodic()));
     connect(ui->percussion, SIGNAL(clicked(bool)),  this,   SLOT(setDrums()));
@@ -123,6 +125,10 @@ BankEditor::BankEditor(QWidget *parent) :
     connect(ui->actionLanguageDefault, SIGNAL(triggered()), this, SLOT(onActionLanguageTriggered()));
 
     loadSettings();
+    m_bank.lfo_enabled = ui->lfoEnable->isChecked();
+    m_bank.lfo_frequency = ui->lfoFrequency->currentIndex();
+    m_bankBackup = m_bank;
+
     initAudio();
 #ifdef ENABLE_MIDI
     QAction *midiInAction = m_midiInAction = new QAction(
@@ -556,6 +562,17 @@ void BankEditor::syncInstrumentName()
             QString::fromUtf8(m_curInst->name) :
             (m_recentPerc ? getMidiInsNameP(m_recentNum) : getMidiInsNameM(m_recentNum))
         );
+    }
+    syncInstrumentBlankness();
+}
+
+void BankEditor::syncInstrumentBlankness()
+{
+    QListWidgetItem *curInstr = ui->instruments->currentItem();
+    if(m_curInst && curInstr)
+    {
+        curInstr->setForeground(m_curInst->is_blank ?
+                                Qt::gray : Qt::black);
     }
 }
 
@@ -1186,6 +1203,8 @@ void BankEditor::setMelodic()
                       m_bank.Ins_Melodic[i].name : getMidiInsNameM(i));
         setInstrumentMetaInfo(item, i);
         item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+        item->setForeground(m_bank.Ins_Melodic[i].is_blank ?
+                            Qt::gray : Qt::black);
         ui->instruments->addItem(item);
     }
     on_bank_no_currentIndexChanged(ui->bank_no->currentIndex());
@@ -1203,6 +1222,8 @@ void BankEditor::setDrums()
                       m_bank.Ins_Percussion[i].name : getMidiInsNameP(i));
         setInstrumentMetaInfo(item, i);
         item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+        item->setForeground(m_bank.Ins_Percussion[i].is_blank ?
+                            Qt::gray : Qt::black);
         ui->instruments->addItem(item);
     }
     on_bank_no_currentIndexChanged(ui->bank_no->currentIndex());
@@ -1224,6 +1245,8 @@ void BankEditor::reloadInstrumentNames()
                 items[i]->setText(m_bank.Ins_Percussion[index].name[0] != '\0' ?
                                   m_bank.Ins_Percussion[index].name :
                                   getMidiInsNameP(index));
+                items[i]->setForeground(m_bank.Ins_Percussion[i].is_blank ?
+                                        Qt::gray : Qt::black);
             }
         }
     }
@@ -1240,6 +1263,8 @@ void BankEditor::reloadInstrumentNames()
                 items[i]->setText(m_bank.Ins_Melodic[index].name[0] != '\0' ?
                                   m_bank.Ins_Melodic[index].name :
                                   getMidiInsNameM(index));
+                items[i]->setForeground(m_bank.Ins_Melodic[i].is_blank ?
+                                        Qt::gray : Qt::black);
             }
         }
     }
@@ -1261,7 +1286,6 @@ void BankEditor::on_actionAddInst_triggered()
     }
     else
     {
-        FmBank::Instrument ins = FmBank::emptyInst();
         m_bank.Ins_Percussion_box.push_back(ins);
         m_bank.Ins_Percussion = m_bank.Ins_Percussion_box.data();
         ins = m_bank.Ins_Percussion_box.last();
@@ -1298,7 +1322,7 @@ void BankEditor::on_actionClearInstrument_triggered()
         return;
     }
 
-    memset(m_curInst, 0, sizeof(FmBank::Instrument));
+    *m_curInst = FmBank::blankInst();
     loadInstrument();
     syncInstrumentName();
 }
@@ -1472,17 +1496,17 @@ void BankEditor::on_actionClearBank_triggered()
         {
             if(needToShoot_end >= m_bank.Ins_Percussion_box.size())
                 needToShoot_end = m_bank.Ins_Percussion_box.size();
-            memset(m_bank.Ins_Percussion + needToShoot_begin,
-                   0,
-                   sizeof(FmBank::Instrument) * size_t(needToShoot_end - needToShoot_begin));
+            std::fill(m_bank.Ins_Percussion + needToShoot_begin,
+                      m_bank.Ins_Percussion + needToShoot_end,
+                      FmBank::blankInst());
         }
         else
         {
             if(needToShoot_end >= m_bank.Ins_Melodic_box.size())
                 needToShoot_end = m_bank.Ins_Melodic_box.size();
-            memset(m_bank.Ins_Melodic + needToShoot_begin,
-                   0,
-                   sizeof(FmBank::Instrument) * size_t(needToShoot_end - needToShoot_begin));
+            std::fill(m_bank.Ins_Melodic + needToShoot_begin,
+                      m_bank.Ins_Melodic + needToShoot_end,
+                      FmBank::blankInst());
         }
         reloadInstrumentNames();
         loadInstrument();

--- a/src/bank_editor.h
+++ b/src/bank_editor.h
@@ -203,9 +203,13 @@ public:
      */
     void flushInstrument();
     /**
-     * @brief Syncronize instrument name in the list widget with actual instrument name in the data store
+     * @brief Synchronize instrument name in the list widget with actual instrument name in the data store
      */
     void syncInstrumentName();
+    /**
+     * @brief Synchronize instrument blank state in the list widget with actual instrument name in the data store
+     */
+    void syncInstrumentBlankness();
     /**
      * @brief Sets current instrument to editand test
      * @param num Number of instrument (from 0 to 127)
@@ -486,6 +490,11 @@ private slots:
     void on_pitchBendSlider_sliderReleased();
 
     void on_holdButton_toggled(bool checked);
+
+    /**
+     * @brief Update after a change of any control value
+     */
+    void afterChangeControlValue();
 
     /**
      * @brief Adjusts the size of the window after it has been shown

--- a/src/controlls.cpp
+++ b/src/controlls.cpp
@@ -56,7 +56,7 @@ void BankEditor::on_feedback1_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->feedback = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_algorithm_currentIndexChanged(int index)
@@ -64,7 +64,7 @@ void BankEditor::on_algorithm_currentIndexChanged(int index)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->algorithm = uint8_t(index);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_amsens_currentIndexChanged(int index)
@@ -72,7 +72,7 @@ void BankEditor::on_amsens_currentIndexChanged(int index)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->am = uint8_t(index);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_fmsens_currentIndexChanged(int index)
@@ -80,7 +80,7 @@ void BankEditor::on_fmsens_currentIndexChanged(int index)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->fm = uint8_t(index);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_perc_noteNum_valueChanged(int arg1)
@@ -90,7 +90,7 @@ void BankEditor::on_perc_noteNum_valueChanged(int arg1)
     m_curInst->percNoteNum = uint8_t(arg1);
     if(ui->percussion->isChecked())
         ui->noteToTest->setValue(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_noteOffset1_valueChanged(int arg1)
@@ -98,7 +98,7 @@ void BankEditor::on_noteOffset1_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->note_offset1 = short(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 
@@ -109,7 +109,7 @@ void BankEditor::on_op1_attack_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR1_HR].attack = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op1_decay1_valueChanged(int arg1)
@@ -117,7 +117,7 @@ void BankEditor::on_op1_decay1_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR1_HR].decay1 = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op1_decay2_valueChanged(int arg1)
@@ -125,7 +125,7 @@ void BankEditor::on_op1_decay2_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR1_HR].decay2 = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op1_sustain_valueChanged(int arg1)
@@ -133,7 +133,7 @@ void BankEditor::on_op1_sustain_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR1_HR].sustain = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op1_release_valueChanged(int arg1)
@@ -141,7 +141,7 @@ void BankEditor::on_op1_release_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR1_HR].release = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op1_am_toggled(bool checked)
@@ -149,7 +149,7 @@ void BankEditor::on_op1_am_toggled(bool checked)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR1_HR].am_enable = uint8_t(checked);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op1_level_valueChanged(int arg1)
@@ -157,7 +157,7 @@ void BankEditor::on_op1_level_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR1_HR].level = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op1_freqmult_valueChanged(int arg1)
@@ -165,7 +165,7 @@ void BankEditor::on_op1_freqmult_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR1_HR].fmult = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op1_detune_currentIndexChanged(int index)
@@ -173,7 +173,7 @@ void BankEditor::on_op1_detune_currentIndexChanged(int index)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR1_HR].detune = uint8_t(index);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op1_ratescale_valueChanged(int arg1)
@@ -181,7 +181,7 @@ void BankEditor::on_op1_ratescale_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR1_HR].ratescale = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op1_ssgeg_currentIndexChanged(int index)
@@ -189,7 +189,7 @@ void BankEditor::on_op1_ssgeg_currentIndexChanged(int index)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR1_HR].ssg_eg = uint8_t(index);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 
@@ -202,7 +202,7 @@ void BankEditor::on_op2_attack_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR2_HR].attack = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op2_decay1_valueChanged(int arg1)
@@ -210,7 +210,7 @@ void BankEditor::on_op2_decay1_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR2_HR].decay1 = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op2_decay2_valueChanged(int arg1)
@@ -218,7 +218,7 @@ void BankEditor::on_op2_decay2_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR2_HR].decay2 = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op2_sustain_valueChanged(int arg1)
@@ -226,7 +226,7 @@ void BankEditor::on_op2_sustain_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR2_HR].sustain = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op2_release_valueChanged(int arg1)
@@ -234,7 +234,7 @@ void BankEditor::on_op2_release_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR2_HR].release = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op2_am_toggled(bool checked)
@@ -242,7 +242,7 @@ void BankEditor::on_op2_am_toggled(bool checked)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR2_HR].am_enable = uint8_t(checked);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op2_level_valueChanged(int arg1)
@@ -250,7 +250,7 @@ void BankEditor::on_op2_level_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR2_HR].level = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op2_freqmult_valueChanged(int arg1)
@@ -258,7 +258,7 @@ void BankEditor::on_op2_freqmult_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR2_HR].fmult = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op2_detune_currentIndexChanged(int index)
@@ -266,7 +266,7 @@ void BankEditor::on_op2_detune_currentIndexChanged(int index)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR2_HR].detune = uint8_t(index);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op2_ratescale_valueChanged(int arg1)
@@ -274,7 +274,7 @@ void BankEditor::on_op2_ratescale_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR2_HR].ratescale = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op2_ssgeg_currentIndexChanged(int index)
@@ -282,7 +282,7 @@ void BankEditor::on_op2_ssgeg_currentIndexChanged(int index)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR2_HR].ssg_eg = uint8_t(index);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 
@@ -294,7 +294,7 @@ void BankEditor::on_op3_attack_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR3_HR].attack = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op3_decay1_valueChanged(int arg1)
@@ -302,7 +302,7 @@ void BankEditor::on_op3_decay1_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR3_HR].decay1 = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op3_decay2_valueChanged(int arg1)
@@ -310,7 +310,7 @@ void BankEditor::on_op3_decay2_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR3_HR].decay2 = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op3_sustain_valueChanged(int arg1)
@@ -318,7 +318,7 @@ void BankEditor::on_op3_sustain_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR3_HR].sustain = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op3_release_valueChanged(int arg1)
@@ -326,7 +326,7 @@ void BankEditor::on_op3_release_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR3_HR].release = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op3_am_toggled(bool checked)
@@ -334,7 +334,7 @@ void BankEditor::on_op3_am_toggled(bool checked)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR3_HR].am_enable = uint8_t(checked);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op3_level_valueChanged(int arg1)
@@ -342,7 +342,7 @@ void BankEditor::on_op3_level_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR3_HR].level = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op3_freqmult_valueChanged(int arg1)
@@ -350,7 +350,7 @@ void BankEditor::on_op3_freqmult_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR3_HR].fmult = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op3_detune_currentIndexChanged(int index)
@@ -358,7 +358,7 @@ void BankEditor::on_op3_detune_currentIndexChanged(int index)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR3_HR].detune = uint8_t(index);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op3_ratescale_valueChanged(int arg1)
@@ -366,7 +366,7 @@ void BankEditor::on_op3_ratescale_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR3_HR].ratescale = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op3_ssgeg_currentIndexChanged(int index)
@@ -374,7 +374,7 @@ void BankEditor::on_op3_ssgeg_currentIndexChanged(int index)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR3_HR].ssg_eg = uint8_t(index);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 
@@ -386,7 +386,7 @@ void BankEditor::on_op4_attack_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR4_HR].attack = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op4_decay1_valueChanged(int arg1)
@@ -394,7 +394,7 @@ void BankEditor::on_op4_decay1_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR4_HR].decay1 = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op4_decay2_valueChanged(int arg1)
@@ -402,7 +402,7 @@ void BankEditor::on_op4_decay2_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR4_HR].decay2 = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op4_sustain_valueChanged(int arg1)
@@ -410,7 +410,7 @@ void BankEditor::on_op4_sustain_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR4_HR].sustain = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op4_release_valueChanged(int arg1)
@@ -418,7 +418,7 @@ void BankEditor::on_op4_release_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR4_HR].release = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op4_am_toggled(bool checked)
@@ -426,7 +426,7 @@ void BankEditor::on_op4_am_toggled(bool checked)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR4_HR].am_enable = uint8_t(checked);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op4_level_valueChanged(int arg1)
@@ -434,7 +434,7 @@ void BankEditor::on_op4_level_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR4_HR].level = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op4_freqmult_valueChanged(int arg1)
@@ -442,7 +442,7 @@ void BankEditor::on_op4_freqmult_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR4_HR].fmult = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op4_detune_currentIndexChanged(int index)
@@ -450,7 +450,7 @@ void BankEditor::on_op4_detune_currentIndexChanged(int index)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR4_HR].detune = uint8_t(index);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op4_ratescale_valueChanged(int arg1)
@@ -458,7 +458,7 @@ void BankEditor::on_op4_ratescale_valueChanged(int arg1)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR4_HR].ratescale = uint8_t(arg1);
-    sendPatch();
+    afterChangeControlValue();
 }
 
 void BankEditor::on_op4_ssgeg_currentIndexChanged(int index)
@@ -466,6 +466,19 @@ void BankEditor::on_op4_ssgeg_currentIndexChanged(int index)
     if(m_lock) return;
     if(!m_curInst) return;
     m_curInst->OP[OPERATOR4_HR].ssg_eg = uint8_t(index);
+    afterChangeControlValue();
+}
+
+/* ***************** All ***************** */
+
+void BankEditor::afterChangeControlValue()
+{
+    Q_ASSERT(m_curInst);
+    if(m_curInst->is_blank)
+    {
+        m_curInst->is_blank = false;
+        syncInstrumentBlankness();
+    }
     sendPatch();
 }
 


### PR DESCRIPTION
Same as OPL3BankEditor, except one important thing:

At startup it's now needed to set the backup like OPL3 does.
(or it will popup the dialog of unsaved changes on "Open" at startup)

At the same place I reciprocated how it syncs the global parameters of banks on OPL3 startup.
(was deep tremolo/vibrato, here LFO settings)

```
    m_bank.lfo_enabled = ui->lfoEnable->isChecked();
    m_bank.lfo_frequency = ui->lfoFrequency->currentIndex();
    m_bankBackup = m_bank;
```