### PR TITLE
fix the compile time definition of ENABLE_PLOTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,9 @@ target_link_libraries(Measurer PUBLIC Chips Common Qt5::Concurrent)
 if(NOT MSVC)
   target_compile_options(Measurer PRIVATE "-fopenmp")
 endif()
+if(ENABLE_PLOTS)
+  target_compile_definitions(Measurer PUBLIC "-DENABLE_PLOTS")
+endif()
 
 set(SOURCES
   "src/audio.cpp"
@@ -160,7 +163,6 @@ add_executable(OPN2BankEditor WIN32 MACOSX_BUNDLE
 set_target_properties(OPN2BankEditor PROPERTIES
   OUTPUT_NAME "opn2_bank_editor")
 if(ENABLE_PLOTS)
-  target_compile_definitions(OPN2BankEditor PRIVATE "-DENABLE_PLOTS")
   target_include_directories(OPN2BankEditor PRIVATE ${QWT_INCLUDE_DIRS})
 endif()
 target_link_libraries(OPN2BankEditor PRIVATE FileFormats Chips Measurer)


### PR DESCRIPTION
Like OPL3, fixes the plot data which is not computed by lack of `ENABLE_PLOTS` definitions.