### PR TITLE
add YMX format loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(FILEFORMATS_SOURCES
   "src/FileFormats/format_gems_pat.cpp"
   "src/FileFormats/format_m2v_gyb.cpp"
   "src/FileFormats/format_tomsoft_gin.cpp"
+  "src/FileFormats/format_saxman_ymx.cpp"
   "src/FileFormats/format_vgm_import.cpp"
   "src/FileFormats/format_gym_import.cpp"
   "src/FileFormats/format_wohlstand_opn2.cpp")

--- a/FMBankEdit.pro
+++ b/FMBankEdit.pro
@@ -105,6 +105,7 @@ SOURCES += \
     src/FileFormats/format_gems_pat.cpp \
     src/FileFormats/format_m2v_gyb.cpp \
     src/FileFormats/format_tomsoft_gin.cpp \
+    src/FileFormats/format_saxman_ymx.cpp \
     src/FileFormats/format_vgm_import.cpp \
     src/FileFormats/format_gym_import.cpp \
     src/FileFormats/format_wohlstand_opn2.cpp \
@@ -150,6 +151,7 @@ HEADERS += \
     src/FileFormats/format_gems_pat.h \
     src/FileFormats/format_m2v_gyb.h \
     src/FileFormats/format_tomsoft_gin.h \
+    src/FileFormats/format_saxman_ymx.h \
     src/FileFormats/format_vgm_import.h \
     src/FileFormats/format_gym_import.h \
     src/FileFormats/format_wohlstand_opn2.h \

--- a/src/FileFormats/ffmt_enums.h
+++ b/src/FileFormats/ffmt_enums.h
@@ -31,6 +31,7 @@ enum BankFormats
     FORMAT_M2V_GYB        = 3,
     FORMAT_TOMSOFT_GIN    = 4,
     FORMAT_GYM_IMPORTER   = 5,
+    FORMAT_SAXMAN_YMX     = 6,
 
     FORMATS_END,
     FORMATS_BEGIN = FORMAT_WOHLSTAND_OPN2,

--- a/src/FileFormats/ffmt_factory.cpp
+++ b/src/FileFormats/ffmt_factory.cpp
@@ -31,6 +31,7 @@
 #include "format_gems_pat.h"
 #include "format_m2v_gyb.h"
 #include "format_tomsoft_gin.h"
+#include "format_saxman_ymx.h"
 
 typedef std::unique_ptr<FmBankFormatBase> FmBankFormatBase_uptr;
 typedef std::list<FmBankFormatBase_uptr>  FmBankFormatsL;
@@ -66,6 +67,7 @@ void FmBankFormatFactory::registerAllFormats()
 #ifdef DEBUG_BUILD // Experimental and unfinished format support. Disable it in release builds
     registerBankFormat(new Tomsoft_GIN());
 #endif
+    registerBankFormat(new Saxman_YMX());
 }
 
 

--- a/src/FileFormats/format_saxman_ymx.cpp
+++ b/src/FileFormats/format_saxman_ymx.cpp
@@ -1,0 +1,145 @@
+/*
+ * OPN2 Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2017-2018 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "format_saxman_ymx.h"
+#include "../common.h"
+#include <QDebug>
+
+bool Saxman_YMX::detect(const QString &filePath, char *magic)
+{
+    return !memcmp(magic, "YM2612", 6);
+}
+
+FfmtErrCode Saxman_YMX::loadFile(QString filePath, FmBank &bank)
+{
+    QFile file(filePath);
+
+    if(!file.open(QIODevice::ReadOnly))
+        return FfmtErrCode::ERR_NOFILE;
+
+    char magic[6] = {};
+    file.read((char *)&magic, 6);
+    if(memcmp(magic, "YM2612", 6))
+        return FfmtErrCode::ERR_BADFORMAT;
+
+    uint8_t revision;
+    if (file.read((char *)&revision, 1) != 1)
+        return FfmtErrCode::ERR_BADFORMAT;
+
+    switch(revision)
+    {
+    case 0:
+        return loadRevision0(file, bank);
+    // TODO the revision 1
+    default:
+        return FfmtErrCode::ERR_BADFORMAT;
+    }
+}
+
+FfmtErrCode Saxman_YMX::loadRevision0(QFile &file, FmBank &bank)
+{
+    uint8_t voiceCount; // count supposed to be N-1, but some files have it as N
+    if (file.read((char *)&voiceCount, 1) != 1)
+        return FfmtErrCode::ERR_BADFORMAT;
+
+    struct RawVoice {
+        char name[11];
+        uint8_t idata[25];
+    };
+
+    std::vector<RawVoice> voices;
+    voices.reserve(voiceCount);
+
+    for(unsigned i = 0; i < voiceCount + 1; ++i)
+    {
+        file.seek(8 + i * 35);
+
+        RawVoice v;
+
+        if (file.read((char *)v.idata, 25) != 25) {
+            if(i == voiceCount)
+                break;  // voice count workaround
+            return FfmtErrCode::ERR_BADFORMAT;
+        }
+
+        if (file.read((char *)v.name, 10) != 10)
+            return FfmtErrCode::ERR_BADFORMAT;
+        v.name[10] = 0;
+
+        size_t namelen = strlen(v.name);
+        while(namelen > 0 && v.name[namelen - 1] == ' ')
+            v.name[--namelen] = '\0';
+
+        voices.push_back(v);
+    }
+
+    if (voices.empty())
+        return FfmtErrCode::ERR_BADFORMAT;
+
+    bank.reset((voices.size() + 127) / 128, 1);
+    for(unsigned i = 0, n = bank.Ins_Melodic_box.size(); i < n; ++i)
+        bank.Ins_Melodic_box[i].is_blank = true;
+    for(unsigned i = 0, n = bank.Ins_Percussion_box.size(); i < n; ++i)
+        bank.Ins_Percussion_box[i].is_blank = true;
+
+    for(unsigned j = 0, n = (unsigned)voices.size(); j < n; ++j)
+    {
+        FmBank::Instrument &inst = bank.Ins_Melodic[j];
+        inst.is_blank = false;
+        strcpy(inst.name, voices[j].name);
+
+        const uint8_t *idata = voices[j].idata;
+        inst.feedback = (idata[0] >> 3) & 7;
+        inst.algorithm = idata[0] & 7;
+
+        for(unsigned i = 0; i < 4; ++i)
+        {
+            const unsigned opnum[] = {OPERATOR1_HR, OPERATOR3_HR, OPERATOR2_HR, OPERATOR4_HR};
+            const unsigned op = opnum[i];
+
+            inst.setRegDUMUL(op, idata[i + 1]);
+            inst.setRegRSAt(op, idata[i + 1 + 4]);
+            inst.setRegAMD1(op, idata[i + 1 + 8]);
+            inst.setRegD2(op, idata[i + 1 + 12]);
+            inst.setRegSysRel(op, idata[i + 1 + 16]);
+            inst.setRegLevel(op, idata[i + 1 + 20]);
+        }
+    }
+
+    return FfmtErrCode::ERR_OK;
+}
+
+int Saxman_YMX::formatCaps() const
+{
+    return (int)FormatCaps::FORMAT_CAPS_OPEN|(int)FormatCaps::FORMAT_CAPS_IMPORT;
+}
+
+QString Saxman_YMX::formatName() const
+{
+    return "YMX bank";
+}
+
+QString Saxman_YMX::formatExtensionMask() const
+{
+    return "*.ymx";
+}
+
+BankFormats Saxman_YMX::formatId() const
+{
+    return BankFormats::FORMAT_SAXMAN_YMX;
+}

--- a/src/FileFormats/format_saxman_ymx.h
+++ b/src/FileFormats/format_saxman_ymx.h
@@ -30,6 +30,7 @@ class Saxman_YMX final : public FmBankFormatBase
 public:
     bool        detect(const QString &filePath, char *magic) override;
     FfmtErrCode loadFile(QString filePath, FmBank &bank) override;
+    FfmtErrCode saveFile(QString filePath, FmBank &bank) override;
     int         formatCaps() const override;
     QString     formatName() const override;
     QString     formatExtensionMask() const override;

--- a/src/FileFormats/format_saxman_ymx.h
+++ b/src/FileFormats/format_saxman_ymx.h
@@ -1,0 +1,42 @@
+/*
+ * OPN2 Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2017-2018 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FORMAT_SAXMAN_YMX_H
+#define FORMAT_SAXMAN_YMX_H
+
+#include "ffmt_base.h"
+class QFile;
+
+/**
+ * @brief Reader and Writer of the GEMS File Format
+ */
+class Saxman_YMX final : public FmBankFormatBase
+{
+public:
+    bool        detect(const QString &filePath, char *magic) override;
+    FfmtErrCode loadFile(QString filePath, FmBank &bank) override;
+    int         formatCaps() const override;
+    QString     formatName() const override;
+    QString     formatExtensionMask() const override;
+    BankFormats formatId() const override;
+
+private:
+    FfmtErrCode loadRevision0(QFile &file, FmBank &bank);
+};
+
+#endif // FORMAT_SAXMAN_YMX_H


### PR DESCRIPTION
It's the revision 0 of format which has existing banks in, not revision 1 specified on sega retro.
Sources are found in Sonic ROM editing tools.

Instrument payload is formatted as SMPS. https://segaretro.org/SCHG:SMPS_Hacking/Voices_and_Samples
It's as usual data formats except operator's fields were interleaved.

Some instruments sound good ~and some are crap~ (FIXED), test it.