### PR TITLE
fixed offset problem of the vgm file reader

### DIFF
--- a/src/FileFormats/format_vgm_import.cpp
+++ b/src/FileFormats/format_vgm_import.cpp
@@ -125,13 +125,14 @@ FfmtErrCode VGM_Importer::load(QIODevice &file, FmBank &bank)
     uint8_t vgm_sizetable[0x100];
     make_size_table(vgm_sizetable, vgm_version);
 
-    file.seek(0x34);
-    file.read(char_p(numb), 4);
-
-    uint32_t data_offset = toUint32LE(numb);
-    if(data_offset == 0x0C)
-        data_offset = 0x40;
-    file.seek(data_offset);
+    uint32_t data_offset = 0xC;
+    if(vgm_version >= 0x150)
+    {
+        file.seek(0x34);
+        file.read(char_p(numb), 4);
+        data_offset = toUint32LE(numb);
+    }
+    file.seek(0x34 + data_offset);
 
     bank.Ins_Melodic_box.clear();
 


### PR DESCRIPTION
With vgz being merged, it has also merged a VGM fix.
However this fix can disrupt the way how data stream is read when the data offset is misinterpreted, because the second fix was not part of the branch.

It means that files which were working before (by chance) can maybe no longer work.
(happened to me on OPL-BE side)

It's the fix found in YM2151 branch by itself, which is recommendable to pick.