### PR TITLE
bti: update for specification 1.2.0

### DIFF
--- a/src/FileFormats/format_bamboo_bti.cpp
+++ b/src/FileFormats/format_bamboo_bti.cpp
@@ -54,7 +54,7 @@ FfmtErrCode Bamboo_BTI::loadFileInst(QString filePath, FmBank::Instrument &inst,
 
     uint32_t file_ver = toUint32LE(temp);
 
-    if(file_ver < btVersion(1, 0, 0) || file_ver > btVersion(1, 1, 0))
+    if(file_ver < btVersion(1, 0, 0) || file_ver > btVersion(1, 2, 0))
         return FfmtErrCode::ERR_BADFORMAT;
 
     // - Instrument Section -


### PR DESCRIPTION
#71

BTI update to specification 1.2.0
Nothing is to add, beside the version check.
Since the size is filled inside file structures, the new data content will be just skipped, and it's nothing of interest to the bank editor.

About BTM (module) it takes more work than to go fish the BTI data structure inside the file, because it's differently organized. I think, if I'm not mistaken, various chunks are arranged at separated places in the files, so it needs a bit different parsing.