### PR TITLE
Importing and exporting with custom text formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,9 @@ set(FILEFORMATS_SOURCES
   "src/FileFormats/format_bamboo_bti.cpp"
   "src/FileFormats/format_wohlstand_opn2.cpp"
   "src/FileFormats/ym2612_to_wopi.cpp"
-  "src/FileFormats/ym2151_to_wopi.cpp")
+  "src/FileFormats/ym2151_to_wopi.cpp"
+  "src/FileFormats/text_format.cpp"
+  "src/FileFormats/text_format_tokens.cpp")
 add_library(FileFormats STATIC ${FILEFORMATS_SOURCES})
 target_include_directories(FileFormats PUBLIC "src" PRIVATE ${ZLIB_INCLUDE_DIRS})
 target_link_libraries(FileFormats PUBLIC Common PRIVATE ${ZLIB_LIBRARIES})

--- a/FMBankEdit.pro
+++ b/FMBankEdit.pro
@@ -124,6 +124,8 @@ SOURCES += \
     src/FileFormats/format_wohlstand_opn2.cpp \
     src/FileFormats/ym2612_to_wopi.cpp \
     src/FileFormats/ym2151_to_wopi.cpp \
+    src/FileFormats/text_format.cpp \
+    src/FileFormats/text_format_tokens.cpp \
     src/formats_sup.cpp \
     src/importer.cpp \
     src/audio_config.cpp \
@@ -164,6 +166,8 @@ HEADERS += \
     src/FileFormats/format_wohlstand_opn2.h \
     src/FileFormats/ym2612_to_wopi.h \
     src/FileFormats/ym2151_to_wopi.h \
+    src/FileFormats/text_format.h \
+    src/FileFormats/text_format_tokens.h \
     src/formats_sup.h \
     src/importer.h \
     src/audio_config.h \

--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -21,6 +21,7 @@
 #include "metaparameter.h"
 #include <cstring>
 #include <cctype>
+#include <climits>
 
 ///
 template <class T> TextFormat &TextFormat::operator<<(const T &token)
@@ -147,6 +148,18 @@ bool TextFormat::parseInstrument(const char *text, FmBank::Instrument &ins) cons
         return std::string(begin, text);
     };
 
+    auto readNextInt = [](const char *&text, int *dest) -> bool
+    {
+        char *end = nullptr;
+        long value = std::strtol(text, &end, 10);
+        if(!end || end == text || value < INT_MIN || value > INT_MAX)
+            return false;
+        text = end;
+        if(dest)
+            *dest = (int)value;
+        return true;
+    };
+
     ///
     using namespace TextFormatTokens;
 
@@ -170,10 +183,8 @@ bool TextFormat::parseInstrument(const char *text, FmBank::Instrument &ins) cons
         case T_Int:
         {
             int value;
-            unsigned count;
-            if(std::sscanf(text, "%d%n", &value, &count) != 1)
+            if (!readNextInt(text, &value))
                 return false;
-            text += count;
             break;
         }
         case T_AlphaNumString:
@@ -189,10 +200,8 @@ bool TextFormat::parseInstrument(const char *text, FmBank::Instrument &ins) cons
         case T_Val:
         {
             int value;
-            unsigned count;
-            if(std::sscanf(text, "%d%n", &value, &count) != 1)
+            if (!readNextInt(text, &value))
                 return false;
-            text += count;
             const MetaParameter *mp = static_cast<Val &>(*token).parameter();
             mp->set(ins, mp->clamp(value));
             break;

--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -172,6 +172,16 @@ bool TextFormat::parseInstrument(const char *text, FmBank::Instrument &ins) cons
             text += count;
             break;
         }
+        case T_AlphaNumString:
+        {
+            std::string value;
+            value.reserve(256);
+            for(char c; (c = *text) != '\0' && std::isalnum((unsigned char)c); ++text)
+                value.push_back(c);
+            if (value.empty())
+                return false;
+            break;
+        }
         case T_Val:
         {
             int value;
@@ -282,7 +292,8 @@ static TextFormat createFmpFormat()
 
     using namespace TextFormatTokens;
 
-    tf << "'" << "@" << " " << Int() << " " << NameString()/*guess*/ << "\n";
+    // permissive parsing on this line
+    tf << "'" << "@" << " " << AlphaNumString("FA") << " " << AlphaNumString("0") << "\n";
 
     for(int o = 0; o < 4; ++o)
     {

--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -1,0 +1,201 @@
+/*
+ * OPN2 Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2017-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "text_format.h"
+#include "text_format_tokens.h"
+#include "metaparameter.h"
+#include <cstring>
+#include <cctype>
+
+///
+template <class T> TextFormat &TextFormat::operator<<(const T &token)
+{
+    m_valid = m_valid && token.isValid();
+    m_tokens.emplace_back(new T(token));
+    return *this;
+}
+
+TextFormat &TextFormat::operator<<(const char *tokenText)
+{
+    using namespace TextFormatTokens;
+
+    if (Whitespace(tokenText).isValid())
+        *this << Whitespace(tokenText);
+    else
+        *this << Symbol(tokenText);
+
+    return *this;
+}
+
+///
+std::string TextFormat::formatInstrument(const FmBank::Instrument &ins) const
+{
+    std::string text;
+
+    if (!isValid())
+        return text;
+
+    using namespace TextFormatTokens;
+
+    for(const TokenPtr &token : m_tokens)
+    {
+        switch(token->type())
+        {
+        default:
+            text.append(token->text());
+            break;
+        case T_Val:
+            text.append(std::to_string(
+                            static_cast<Val &>(*token).parameter()->get(ins)));
+            break;
+        case T_NameString:
+            text.append(ins.name);
+            break;
+        }
+    }
+
+    return text;
+}
+
+bool TextFormat::parseInstrument(const char *text, FmBank::Instrument &ins) const
+{
+    ins = FmBank::emptyInst();
+
+    const std::string &lc = m_lineComment;
+
+    ///
+    auto skipWhitespace = [&text, lc]()
+    {
+        for(bool endWs = false; !endWs;)
+        {
+            if (std::isspace((unsigned char)*text))
+                ++text;
+            else if(!lc.empty() && std::strncmp(text, lc.data(), lc.size()) == 0)
+            {
+                text += lc.size();
+                while(*text != '\0' && *text != '\r' && *text != '\n')
+                    ++text;
+            }
+            else
+                endWs = true;
+        }
+    };
+
+    auto readUntilEolOrComment = [&text, lc]() -> std::string
+    {
+        const char *begin = text;
+        while(*text != '\0' && *text != '\r' && *text != '\n' &&
+              !(!lc.empty() && std::strncmp(text, lc.data(), lc.size()) == 0))
+              ++text;
+        return std::string(begin, text);
+    };
+
+    ///
+    using namespace TextFormatTokens;
+
+    for(const TokenPtr &token : m_tokens)
+    {
+        skipWhitespace();
+
+        switch(token->type())
+        {
+        case T_Symbol:
+        {
+            const char *sym = static_cast<Symbol &>(*token).text();
+            size_t len = strlen(sym);
+            if(std::strncmp(text, sym, len))
+                return false;
+            text += len;
+            break;
+        }
+        case T_Whitespace:
+            break;
+        case T_Int:
+        {
+            int value;
+            unsigned count;
+            if(std::sscanf(text, "%d%n", &value, &count) != 1)
+                return false;
+            text += count;
+            break;
+        }
+        case T_Val:
+        {
+            int value;
+            unsigned count;
+            if(std::sscanf(text, "%d%n", &value, &count) != 1)
+                return false;
+            text += count;
+            const MetaParameter *mp = static_cast<Val &>(*token).parameter();
+            mp->set(ins, mp->clamp(value));
+            break;
+        }
+        case T_NameString:
+        {
+            std::string name = readUntilEolOrComment();
+            std::strncpy(ins.name, name.c_str(), 32);
+            break;
+        }
+        }
+    }
+
+    return true;
+}
+
+///
+static TextFormat createVopmFormat()
+{
+    TextFormat tf;
+
+    tf.setLineComment("//");
+
+    using namespace TextFormatTokens;
+
+    tf << "@" << ":"
+              << " " << Int() << " " << NameString() << "\n"
+       << "LFO" << ":"
+                << " " << Int() << " " << Int()
+                << " " << Int() << " " << Int()
+                << " " << Int() << "\n"
+       << "CH" << ":"
+               << " " << Int(64) << " " << Val("fb")
+               << " " << Val("alg") << " " << Int()
+               << " " << Int() << " " << Int(120)
+               << " " << Int() << "\n";
+
+    for(int o = 0; o < 4; ++o)
+    {
+        const char *opnames[] = {"M1", "C1", "M2", "C2"};
+        int op = MP_Operator1 + o;
+        tf << opnames[o] << ":"
+           << " " << Val("ar", op) << " " << Val("d1r", op)
+           << " " << Val("d2r", op) << " " << Val("rr", op)
+           << " " << Val("d1l", op) << " " << Val("tl", op)
+           << " " << Val("rs", op) << " " << Val("mul", op)
+           << " " << Val("dt", op) << " " << Int()
+           << " " << Val("am", op) << "\n";
+    }
+
+    return tf;
+}
+
+const TextFormat &TextFormat::vopmFormat()
+{
+    static TextFormat tf = createVopmFormat();
+    return tf;
+}

--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -279,6 +279,34 @@ static TextFormat createFmpFormat()
     return tf;
 }
 
+static TextFormat createNotexFormat()
+{
+    TextFormat tf;
+
+    tf.setName("NOTE.X");
+    tf.setLineComment("//");
+
+    using namespace TextFormatTokens;
+
+    tf << "@" << Int() << " " << "=" << " " << "{" << "\n";
+
+    for(int o = 0; o < 4; ++o)
+    {
+        int op = MP_Operator1 + o;
+        tf << Val("ar", op) << "," << Val("d1r", op)
+           << "," << Val("d2r", op) << "," << Val("rr", op)
+           << "," << Val("d1l", op) << "," << Val("tl", op)
+           << "," << Val("rs", op) << "," << Val("mul", op)
+           << "," << Val("dt", op) << "," << Int()
+           << "," << Val("am", op) << "\n";
+    }
+
+    tf << Val("alg") << "," << Val("fb") << "," << Int(15) << "\n"
+       << "}" << "\n";
+
+    return tf;
+}
+
 ///
 const TextFormat &TextFormat::vopmFormat()
 {
@@ -298,12 +326,19 @@ const TextFormat &TextFormat::fmpFormat()
     return tf;
 }
 
+const TextFormat &TextFormat::notexFormat()
+{
+    static TextFormat tf = createNotexFormat();
+    return tf;
+}
+
 const std::vector<const TextFormat *> &TextFormat::allFormats()
 {
     static const std::vector<const TextFormat *> all = {
         &vopmFormat(),
         &pmdFormat(),
         &fmpFormat(),
+        &notexFormat(),
     };
     return all;
 }

--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -195,9 +195,40 @@ static TextFormat createVopmFormat()
     return tf;
 }
 
+static TextFormat createPmdFormat()
+{
+    TextFormat tf;
+
+    tf.setName("PMD");
+    tf.setLineComment(";");
+
+    using namespace TextFormatTokens;
+
+    tf << "@" << " " << Int() << " " << Val("alg") << " " << Val("fb") << "\n";
+
+    for(int o = 0; o < 4; ++o)
+    {
+        int op = MP_Operator1 + o;
+        tf << " " << Val("ar", op) << " " << Val("d1r", op)
+           << " " << Val("d2r", op) << " " << Val("rr", op)
+           << " " << Val("d1l", op) << " " << Val("tl", op)
+           << " " << Val("rs", op) << " " << Val("mul", op)
+           << " " << Val("dt", op) << " " << Val("am", op) << "\n";
+    }
+
+    return tf;
+}
+
+///
 const TextFormat &TextFormat::vopmFormat()
 {
     static TextFormat tf = createVopmFormat();
+    return tf;
+}
+
+const TextFormat &TextFormat::pmdFormat()
+{
+    static TextFormat tf = createPmdFormat();
     return tf;
 }
 
@@ -205,6 +236,7 @@ const std::vector<const TextFormat *> &TextFormat::allFormats()
 {
     static const std::vector<const TextFormat *> all = {
         &vopmFormat(),
+        &pmdFormat(),
     };
     return all;
 }

--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -307,6 +307,35 @@ static TextFormat createNotexFormat()
     return tf;
 }
 
+static TextFormat createNrtdrvFormat()
+{
+    TextFormat tf;
+
+    tf.setName("NRTDRV");
+    tf.setLineComment(";");
+
+    using namespace TextFormatTokens;
+
+    tf << "@" << Int() << " " << "{" << "\n";
+
+    tf << Int() << "," << Val("alg") << "," << Val("fb") << "," << Int(15) << "\n";
+
+    for(int o = 0; o < 4; ++o)
+    {
+        int op = MP_Operator1 + o;
+        tf << Val("ar", op) << "," << Val("d1r", op)
+           << "," << Val("d2r", op) << "," << Val("rr", op)
+           << "," << Val("d1l", op) << "," << Val("tl", op)
+           << "," << Val("rs", op) << "," << Val("mul", op)
+           << "," << Val("dt", op) << "," << Int()
+           << "," << Val("am", op) << "\n";
+    }
+
+    tf << "}" << "\n";
+
+    return tf;
+}
+
 ///
 const TextFormat &TextFormat::vopmFormat()
 {
@@ -332,6 +361,12 @@ const TextFormat &TextFormat::notexFormat()
     return tf;
 }
 
+const TextFormat &TextFormat::nrtdrvFormat()
+{
+    static TextFormat tf = createNrtdrvFormat();
+    return tf;
+}
+
 const std::vector<const TextFormat *> &TextFormat::allFormats()
 {
     static const std::vector<const TextFormat *> all = {
@@ -339,6 +374,7 @@ const std::vector<const TextFormat *> &TextFormat::allFormats()
         &pmdFormat(),
         &fmpFormat(),
         &notexFormat(),
+        &nrtdrvFormat(),
     };
     return all;
 }

--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -162,6 +162,7 @@ static TextFormat createVopmFormat()
 {
     TextFormat tf;
 
+    tf.setName("VOPM");
     tf.setLineComment("//");
 
     using namespace TextFormatTokens;
@@ -198,4 +199,20 @@ const TextFormat &TextFormat::vopmFormat()
 {
     static TextFormat tf = createVopmFormat();
     return tf;
+}
+
+const std::vector<const TextFormat *> &TextFormat::allFormats()
+{
+    static const std::vector<const TextFormat *> all = {
+        &vopmFormat(),
+    };
+    return all;
+}
+
+const TextFormat *TextFormat::getFormatByName(const std::string &name)
+{
+    for(const TextFormat *tf : TextFormat::allFormats())
+        if(name == tf->name())
+            return tf;
+    return nullptr;
 }

--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -60,9 +60,13 @@ std::string TextFormat::formatInstrument(const FmBank::Instrument &ins) const
             text.append(token->text());
             break;
         case T_Val:
-            text.append(std::to_string(
-                            static_cast<Val &>(*token).parameter()->get(ins)));
+        {
+            int value = static_cast<Val &>(*token).parameter()->get(ins);
+            char buffer[32];
+            std::sprintf(buffer, static_cast<Val &>(*token).format(), value);
+            text.append(buffer);
             break;
+        }
         case T_NameString:
             text.append(ins.name);
             break;
@@ -320,7 +324,7 @@ static TextFormat createNotexFormat()
 
     using namespace TextFormatTokens;
 
-    tf << "@" << Int() << " " << "=" << " " << "{" << "\n";
+    tf << "@" << Int(0, "%d") << " " << "=" << " " << "{" << "\n";
 
     for(int o = 0; o < 4; ++o)
     {

--- a/src/FileFormats/text_format.h
+++ b/src/FileFormats/text_format.h
@@ -36,6 +36,7 @@ class TextFormat
 public:
     static const TextFormat &vopmFormat();
     static const TextFormat &pmdFormat();
+    static const TextFormat &fmpFormat();
 
     static const std::vector<const TextFormat *> &allFormats();
     static const TextFormat *getFormatByName(const std::string &name);
@@ -48,6 +49,7 @@ public:
 
     //
     void setLineComment(const std::string &com) { m_lineComment = com; }
+    void setLineKeepPrefix(const std::string &prefix) { m_lineKeepPrefix = prefix; }
 
     //
     template <class T> TextFormat &operator<<(const T &token);
@@ -60,7 +62,8 @@ public:
 protected:
     bool m_valid = true;
     std::string m_name;
-    std::string m_lineComment;
+    std::string m_lineComment; // a line comment syntax, most often `//` or `;`
+    std::string m_lineKeepPrefix; // a prefix of text lines not to discard (`'` in the case of FMP)
     std::vector<TextFormatTokens::TokenPtr> m_tokens;
 };
 

--- a/src/FileFormats/text_format.h
+++ b/src/FileFormats/text_format.h
@@ -37,6 +37,7 @@ public:
     static const TextFormat &vopmFormat();
     static const TextFormat &pmdFormat();
     static const TextFormat &fmpFormat();
+    static const TextFormat &notexFormat();
 
     static const std::vector<const TextFormat *> &allFormats();
     static const TextFormat *getFormatByName(const std::string &name);

--- a/src/FileFormats/text_format.h
+++ b/src/FileFormats/text_format.h
@@ -39,6 +39,7 @@ public:
     static const TextFormat &fmpFormat();
     static const TextFormat &notexFormat();
     static const TextFormat &nrtdrvFormat();
+    static const TextFormat &mucom88Format();
 
     static const std::vector<const TextFormat *> &allFormats();
     static const TextFormat *getFormatByName(const std::string &name);

--- a/src/FileFormats/text_format.h
+++ b/src/FileFormats/text_format.h
@@ -38,6 +38,7 @@ public:
     static const TextFormat &pmdFormat();
     static const TextFormat &fmpFormat();
     static const TextFormat &notexFormat();
+    static const TextFormat &nrtdrvFormat();
 
     static const std::vector<const TextFormat *> &allFormats();
     static const TextFormat *getFormatByName(const std::string &name);

--- a/src/FileFormats/text_format.h
+++ b/src/FileFormats/text_format.h
@@ -1,0 +1,59 @@
+/*
+ * OPN2 Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2017-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TEXT_FORMAT_H
+#define TEXT_FORMAT_H
+
+#include "bank.h"
+#include <string>
+#include <vector>
+#include <memory>
+
+///
+namespace TextFormatTokens {
+class Token;
+typedef std::unique_ptr<Token> TokenPtr;
+}
+
+///
+class TextFormat
+{
+public:
+    static const TextFormat &vopmFormat();
+
+public:
+    bool isValid() const { return m_valid; }
+
+    //
+    void setLineComment(const std::string &com) { m_lineComment = com; }
+
+    //
+    template <class T> TextFormat &operator<<(const T &token);
+    TextFormat &operator<<(const char *tokenText);
+
+    //
+    std::string formatInstrument(const FmBank::Instrument &ins) const;
+    bool parseInstrument(const char *text, FmBank::Instrument &ins) const;
+
+protected:
+    bool m_valid = true;
+    std::string m_lineComment;
+    std::vector<TextFormatTokens::TokenPtr> m_tokens;
+};
+
+#endif

--- a/src/FileFormats/text_format.h
+++ b/src/FileFormats/text_format.h
@@ -36,8 +36,14 @@ class TextFormat
 public:
     static const TextFormat &vopmFormat();
 
+    static const std::vector<const TextFormat *> &allFormats();
+    static const TextFormat *getFormatByName(const std::string &name);
+
 public:
     bool isValid() const { return m_valid; }
+
+    const std::string &name() const { return m_name; }
+    void setName(const std::string &name) { m_name = name; }
 
     //
     void setLineComment(const std::string &com) { m_lineComment = com; }
@@ -52,6 +58,7 @@ public:
 
 protected:
     bool m_valid = true;
+    std::string m_name;
     std::string m_lineComment;
     std::vector<TextFormatTokens::TokenPtr> m_tokens;
 };

--- a/src/FileFormats/text_format.h
+++ b/src/FileFormats/text_format.h
@@ -35,6 +35,7 @@ class TextFormat
 {
 public:
     static const TextFormat &vopmFormat();
+    static const TextFormat &pmdFormat();
 
     static const std::vector<const TextFormat *> &allFormats();
     static const TextFormat *getFormatByName(const std::string &name);

--- a/src/FileFormats/text_format_tokens.cpp
+++ b/src/FileFormats/text_format_tokens.cpp
@@ -36,6 +36,12 @@ bool Whitespace::isValid() const
 }
 
 ///
+Conditional::Conditional(TokenSharedPtr cond, TokenList ifTrue, TokenList ifFalse, bool defaultValue)
+    : m_cond(std::move(cond)), m_ifTrue(std::move(ifTrue)), m_ifFalse(std::move(ifFalse)), m_defaultValue(defaultValue)
+{
+}
+
+///
 Int::Int(int defaultValue, const char *format)
     : m_defaultValue(defaultValue), m_format(format)
 {

--- a/src/FileFormats/text_format_tokens.cpp
+++ b/src/FileFormats/text_format_tokens.cpp
@@ -36,19 +36,20 @@ bool Whitespace::isValid() const
 }
 
 ///
-Int::Int(int defaultValue)
-    : m_defaultValue(defaultValue)
+Int::Int(int defaultValue, const char *format)
+    : m_defaultValue(defaultValue), m_format(format)
 {
 }
 
 const char *Int::text() const
 {
-    std::sprintf(m_buf, "%d", m_defaultValue);
+    std::sprintf(m_buf, m_format, m_defaultValue);
     return m_buf;
 }
 
 ///
-Val::Val(const char *id, unsigned flags)
+Val::Val(const char *id, unsigned flags, const char *format)
+    : m_format(format)
 {
     for(const MetaParameter &mp : MP_instrument)
     {

--- a/src/FileFormats/text_format_tokens.cpp
+++ b/src/FileFormats/text_format_tokens.cpp
@@ -29,8 +29,8 @@ bool Whitespace::isValid() const
 {
     for(const char *p = m_text; *p != '\0'; ++p)
     {
-        if(!std::isspace((unsigned char)*p))
-            return false;;
+        if(!std::strchr(m_whiteChars, *p))
+            return false;
     }
     return true;
 }

--- a/src/FileFormats/text_format_tokens.cpp
+++ b/src/FileFormats/text_format_tokens.cpp
@@ -1,0 +1,76 @@
+/*
+ * OPN2 Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2017-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "text_format_tokens.h"
+#include "metaparameter.h"
+#include <cstdio>
+#include <cstring>
+#include <cctype>
+
+namespace TextFormatTokens {
+
+///
+bool Whitespace::isValid() const
+{
+    for(const char *p = m_text; *p != '\0'; ++p)
+    {
+        if(!std::isspace((unsigned char)*p))
+            return false;;
+    }
+    return true;
+}
+
+///
+Int::Int(int defaultValue)
+    : m_defaultValue(defaultValue)
+{
+}
+
+const char *Int::text() const
+{
+    std::sprintf(m_buf, "%d", m_defaultValue);
+    return m_buf;
+}
+
+///
+Val::Val(const char *id, unsigned flags)
+{
+    for(const MetaParameter &mp : MP_instrument)
+    {
+        if((mp.flags & flags) == flags && !std::strcmp(id, mp.name))
+        {
+            m_param = &mp;
+            break;
+        }
+    }
+}
+
+const char *Val::text() const
+{
+    if(!isValid())
+        return "";
+
+    return m_param->name;
+}
+
+bool Val::isValid() const
+{
+    return m_param != nullptr;
+}
+
+} // namespace TextFormatTokens

--- a/src/FileFormats/text_format_tokens.h
+++ b/src/FileFormats/text_format_tokens.h
@@ -31,6 +31,7 @@ enum Type
     T_Int,
     T_Val,
     T_NameString,
+    T_QuotedNameString,
 };
 
 ///
@@ -105,6 +106,14 @@ class NameString : public Token
 public:
     Type type() const override { return T_NameString; }
     const char *text() const override { return "Untitled"; }
+    bool isValid() const override { return true; }
+};
+
+class QuotedNameString : public Token
+{
+public:
+    Type type() const override { return T_QuotedNameString; }
+    const char *text() const override { return "\"Untitled\""; }
     bool isValid() const override { return true; }
 };
 

--- a/src/FileFormats/text_format_tokens.h
+++ b/src/FileFormats/text_format_tokens.h
@@ -68,9 +68,12 @@ public:
 class Whitespace : public StaticText
 {
 public:
-    explicit Whitespace(const char *text) : StaticText(text) {}
+    explicit Whitespace(const char *text, const char *wschars = " \t\r\n") : StaticText(text), m_whiteChars(wschars) {}
     Type type() const override { return T_Whitespace; }
     bool isValid() const override;
+    const char *whiteChars() const { return m_whiteChars; }
+private:
+    const char *m_whiteChars;
 };
 
 ///

--- a/src/FileFormats/text_format_tokens.h
+++ b/src/FileFormats/text_format_tokens.h
@@ -1,0 +1,113 @@
+/*
+ * OPN2 Bank Editor by Wohlstand, a free tool for music bank editing
+ * Copyright (c) 2017-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TEXT_FORMAT_TOKENS_H
+#define TEXT_FORMAT_TOKENS_H
+
+struct MetaParameter;
+
+namespace TextFormatTokens {
+
+///
+enum Type
+{
+    T_Symbol,
+    T_Whitespace,
+    T_Int,
+    T_Val,
+    T_NameString,
+};
+
+///
+class Token
+{
+public:
+    virtual ~Token() {}
+    virtual Type type() const = 0;
+    virtual bool isValid() const { return true; }
+    virtual const char *text() const = 0;
+};
+
+///
+class StaticText : public Token
+{
+public:
+    explicit StaticText(const char *text) : m_text(text) {}
+    const char *text() const override { return m_text; }
+
+protected:
+    const char *const m_text;
+};
+
+///
+class Symbol : public StaticText
+{
+public:
+    explicit Symbol(const char *text) : StaticText(text) {}
+    Type type() const override { return T_Symbol; }
+};
+
+///
+class Whitespace : public StaticText
+{
+public:
+    explicit Whitespace(const char *text) : StaticText(text) {}
+    Type type() const override { return T_Whitespace; }
+    bool isValid() const override;
+};
+
+///
+class Int : public Token
+{
+public:
+    explicit Int(int defaultValue = 0);
+    Type type() const override { return T_Int; }
+    const char *text() const override;
+
+private:
+    int m_defaultValue;
+    mutable char m_buf[32];
+};
+
+///
+class Val : public Token
+{
+public:
+    explicit Val(const char *id, unsigned flags = 0);
+    Type type() const override { return T_Val; }
+    const char *text() const override;
+    bool isValid() const override;
+
+    const MetaParameter *parameter() const { return m_param; }
+
+private:
+    const MetaParameter *m_param = nullptr;
+};
+
+///
+class NameString : public Token
+{
+public:
+    Type type() const override { return T_NameString; }
+    const char *text() const override { return "Untitled"; }
+    bool isValid() const override { return true; }
+};
+
+} // namespace TextFormatTokens
+
+#endif // TEXT_FORMAT_TOKENS_H

--- a/src/FileFormats/text_format_tokens.h
+++ b/src/FileFormats/text_format_tokens.h
@@ -29,6 +29,7 @@ enum Type
     T_Symbol,
     T_Whitespace,
     T_Int,
+    T_AlphaNumString,
     T_Val,
     T_NameString,
     T_QuotedNameString,
@@ -83,6 +84,18 @@ public:
 private:
     int m_defaultValue;
     mutable char m_buf[32];
+};
+
+///
+class AlphaNumString : public Token
+{
+public:
+    explicit AlphaNumString(const char *defaultValue) : m_defaultValue(defaultValue) {}
+    Type type() const override { return T_AlphaNumString; }
+    const char *text() const override { return m_defaultValue; }
+
+private:
+    const char *m_defaultValue;
 };
 
 ///

--- a/src/FileFormats/text_format_tokens.h
+++ b/src/FileFormats/text_format_tokens.h
@@ -77,12 +77,14 @@ public:
 class Int : public Token
 {
 public:
-    explicit Int(int defaultValue = 0);
+    explicit Int(int defaultValue = 0, const char *format = "%3d");
     Type type() const override { return T_Int; }
     const char *text() const override;
+    const char *format() const { return m_format; }
 
 private:
     int m_defaultValue;
+    const char *m_format;
     mutable char m_buf[32];
 };
 
@@ -102,15 +104,17 @@ private:
 class Val : public Token
 {
 public:
-    explicit Val(const char *id, unsigned flags = 0);
+    explicit Val(const char *id, unsigned flags = 0, const char *format = "%3d");
     Type type() const override { return T_Val; }
     const char *text() const override;
     bool isValid() const override;
+    const char *format() const { return m_format; }
 
     const MetaParameter *parameter() const { return m_param; }
 
 private:
     const MetaParameter *m_param = nullptr;
+    const char *m_format;
 };
 
 ///

--- a/src/bank_editor.cpp
+++ b/src/bank_editor.cpp
@@ -137,16 +137,11 @@ BankEditor::BankEditor(QWidget *parent) :
     }
 
     {
-        const TextFormat *currentFormat = TextFormat::allFormats().front();
-        //TODO load it from settings
-        m_textconvFormat = currentFormat;
-
         QMenu *textconvMenu = new QMenu(this);
         ui->textconvButton->setMenu(textconvMenu);
 
-        QString currentFormatName = QString::fromStdString(currentFormat->name());
-        m_textconvCopyAction = textconvMenu->addAction(tr("Copy to %1").arg(currentFormatName));
-        m_textconvPasteAction = textconvMenu->addAction(tr("Paste from %1").arg(currentFormatName));
+        m_textconvCopyAction = textconvMenu->addAction("");
+        m_textconvPasteAction = textconvMenu->addAction("");
 
         connect(m_textconvCopyAction, SIGNAL(triggered()), this, SLOT(onTextconvCopyTriggered()));
         connect(m_textconvPasteAction, SIGNAL(triggered()), this, SLOT(onTextconvPasteTriggered()));
@@ -164,6 +159,8 @@ BankEditor::BankEditor(QWidget *parent) :
         }
 
         ui->textconvButton->setPopupMode(QToolButton::InstantPopup);
+
+        setTextconvFormat(*TextFormat::allFormats().front());
     }
 
     ui->instruments->installEventFilter(this);
@@ -274,6 +271,10 @@ void BankEditor::loadSettings()
         ui->actionEmulatorPMDWinOPNA->setChecked(true);
         break;
     }
+
+    if(const TextFormat *tf = TextFormat::getFormatByName(
+           setup.value("text-conversion-format").toString().toStdString()))
+        setTextconvFormat(*tf);
 }
 
 void BankEditor::saveSettings()
@@ -284,6 +285,7 @@ void BankEditor::saveSettings()
     setup.setValue("language", m_language);
     setup.setValue("audio-latency", m_audioLatency);
     setup.setValue("audio-device", m_audioDevice);
+    setup.setValue("text-conversion-format", QString::fromStdString(m_textconvFormat->name()));
 }
 
 
@@ -1874,7 +1876,13 @@ void BankEditor::onTextconvFormatSelected()
     if(!currentFormat)
         return;
 
-    m_textconvFormat = currentFormat;
-    m_textconvCopyAction->setText(tr("Copy to %1").arg(currentFormatName));
-    m_textconvPasteAction->setText(tr("Paste from %1").arg(currentFormatName));
+    setTextconvFormat(*currentFormat);
+}
+
+void BankEditor::setTextconvFormat(const TextFormat &format)
+{
+    QString name = QString::fromStdString(format.name());
+    m_textconvFormat = &format;
+    m_textconvCopyAction->setText(tr("Copy to %1").arg(name));
+    m_textconvPasteAction->setText(tr("Paste from %1").arg(name));
 }

--- a/src/bank_editor.h
+++ b/src/bank_editor.h
@@ -514,6 +514,11 @@ private slots:
     void onTextconvPasteTriggered();
     void onTextconvFormatSelected();
 
+    /**
+     * @brief Changes the current text conversion format, and updates the view accordingly
+     */
+    void setTextconvFormat(const TextFormat &format);
+
 private:
     /**
      * @brief Updates the text to display after a language change

--- a/src/bank_editor.h
+++ b/src/bank_editor.h
@@ -44,6 +44,7 @@ namespace Ui
 }
 
 class Importer;
+class TextFormat;
 class QActionGroup;
 
 /**
@@ -125,6 +126,11 @@ private:
     MidiInRt        *m_midiIn = nullptr;
     QAction         *m_midiInAction = nullptr;
     #endif
+
+    /* ********** Text formatting stuff ********** */
+    const TextFormat *m_textconvFormat = nullptr;
+    QAction *m_textconvCopyAction = nullptr;
+    QAction *m_textconvPasteAction = nullptr;
 
     /*!
      * \brief Initializes audio subsystem and FM generator
@@ -503,6 +509,10 @@ private slots:
     void on_midiIn_triggered(QAction *);
     void onMidiPortTriggered();
     #endif
+
+    void onTextconvCopyTriggered();
+    void onTextconvPasteTriggered();
+    void onTextconvFormatSelected();
 
 private:
     /**

--- a/src/bank_editor.ui
+++ b/src/bank_editor.ui
@@ -601,6 +601,9 @@
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
                   </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Maximum</enum>
+                  </property>
                   <property name="sizeHint" stdset="0">
                    <size>
                     <width>10</width>
@@ -827,6 +830,29 @@
                   </property>
                   <property name="maxLength">
                    <number>32</number>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_4">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Maximum</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>10</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QToolButton" name="textconvButton">
+                  <property name="text">
+                   <string>Convert</string>
                   </property>
                  </widget>
                 </item>
@@ -1605,7 +1631,7 @@ Available from 0 to 127</string>
      <x>0</x>
      <y>0</y>
      <width>950</width>
-     <height>17</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">


### PR DESCRIPTION
#81

Hi, this shows a concept of using custom text formats for reading and writing.
It's not implemented yet in the editor, and only has VOPM as a format now.

In `createVopmFormat`, it can be seen how to build a grammar for a format.
The `Val`s are to replace with the actual values of the instrument. To associate with values, it relies on MetaParameter, which has been given a setter function.
The `Int`s are just number fields which are ignored, and have defaults used for writing.

While writing, the whitespace tokens are used for human-readable formatting.
During parsing, the whitespace tokens are always ignored.