### PR TITLE
Support PMD instrument type 2

### DIFF
--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -26,14 +26,14 @@
 #include <cassert>
 
 ///
-template <class T> TextFormat &TextFormat::operator<<(const T &token)
+template <class T> GrammaticalTextFormat &GrammaticalTextFormat::operator<<(const T &token)
 {
     m_valid = m_valid && token.isValid();
     m_tokens.emplace_back(new T(token));
     return *this;
 }
 
-TextFormat &TextFormat::operator<<(const char *tokenText)
+GrammaticalTextFormat &GrammaticalTextFormat::operator<<(const char *tokenText)
 {
     using namespace TextFormatTokens;
 
@@ -46,7 +46,7 @@ TextFormat &TextFormat::operator<<(const char *tokenText)
 }
 
 ///
-std::string TextFormat::formatInstrument(const FmBank::Instrument &ins) const
+std::string GrammaticalTextFormat::formatInstrument(const FmBank::Instrument &ins) const
 {
     std::string text;
 
@@ -105,7 +105,7 @@ std::string TextFormat::formatInstrument(const FmBank::Instrument &ins) const
     return text;
 }
 
-bool TextFormat::parseInstrument(const char *text, FmBank::Instrument &ins) const
+bool GrammaticalTextFormat::parseInstrument(const char *text, FmBank::Instrument &ins) const
 {
     ins = FmBank::emptyInst();
 
@@ -315,9 +315,9 @@ bool TextFormat::parseInstrument(const char *text, FmBank::Instrument &ins) cons
 }
 
 ///
-static TextFormat createVopmFormat()
+static GrammaticalTextFormat createVopmFormat()
 {
-    TextFormat tf;
+    GrammaticalTextFormat tf;
 
     tf.setName("VOPM");
     tf.setLineComment("//");
@@ -352,9 +352,9 @@ static TextFormat createVopmFormat()
     return tf;
 }
 
-static TextFormat createPmdFormat()
+static GrammaticalTextFormat createPmdFormat()
 {
-    TextFormat tf;
+    GrammaticalTextFormat tf;
 
     tf.setName("PMD");
     tf.setLineComment(";");
@@ -386,9 +386,9 @@ static TextFormat createPmdFormat()
     return tf;
 }
 
-static TextFormat createFmpFormat()
+static GrammaticalTextFormat createFmpFormat()
 {
-    TextFormat tf;
+    GrammaticalTextFormat tf;
 
     tf.setName("FMP");
     tf.setLineKeepPrefix("'");
@@ -414,9 +414,9 @@ static TextFormat createFmpFormat()
     return tf;
 }
 
-static TextFormat createNotexFormat()
+static GrammaticalTextFormat createNotexFormat()
 {
-    TextFormat tf;
+    GrammaticalTextFormat tf;
 
     tf.setName("NOTE.X");
     tf.setLineComment("//");
@@ -442,9 +442,9 @@ static TextFormat createNotexFormat()
     return tf;
 }
 
-static TextFormat createNrtdrvFormat()
+static GrammaticalTextFormat createNrtdrvFormat()
 {
-    TextFormat tf;
+    GrammaticalTextFormat tf;
 
     tf.setName("NRTDRV");
     tf.setLineComment(";");
@@ -471,9 +471,9 @@ static TextFormat createNrtdrvFormat()
     return tf;
 }
 
-static TextFormat createMucom88Format()
+static GrammaticalTextFormat createMucom88Format()
 {
-    TextFormat tf;
+    GrammaticalTextFormat tf;
 
     tf.setName("MUCOM88");
     tf.setLineComment(";");
@@ -503,43 +503,43 @@ static TextFormat createMucom88Format()
 }
 
 ///
-const TextFormat &TextFormat::vopmFormat()
+const TextFormat &TextFormats::vopmFormat()
 {
-    static TextFormat tf = createVopmFormat();
+    static GrammaticalTextFormat tf = createVopmFormat();
     return tf;
 }
 
-const TextFormat &TextFormat::pmdFormat()
+const TextFormat &TextFormats::pmdFormat()
 {
-    static TextFormat tf = createPmdFormat();
+    static GrammaticalTextFormat tf = createPmdFormat();
     return tf;
 }
 
-const TextFormat &TextFormat::fmpFormat()
+const TextFormat &TextFormats::fmpFormat()
 {
-    static TextFormat tf = createFmpFormat();
+    static GrammaticalTextFormat tf = createFmpFormat();
     return tf;
 }
 
-const TextFormat &TextFormat::notexFormat()
+const TextFormat &TextFormats::notexFormat()
 {
-    static TextFormat tf = createNotexFormat();
+    static GrammaticalTextFormat tf = createNotexFormat();
     return tf;
 }
 
-const TextFormat &TextFormat::nrtdrvFormat()
+const TextFormat &TextFormats::nrtdrvFormat()
 {
-    static TextFormat tf = createNrtdrvFormat();
+    static GrammaticalTextFormat tf = createNrtdrvFormat();
     return tf;
 }
 
-const TextFormat &TextFormat::mucom88Format()
+const TextFormat &TextFormats::mucom88Format()
 {
-    static TextFormat tf = createMucom88Format();
+    static GrammaticalTextFormat tf = createMucom88Format();
     return tf;
 }
 
-const std::vector<const TextFormat *> &TextFormat::allFormats()
+const std::vector<const TextFormat *> &TextFormats::allFormats()
 {
     static const std::vector<const TextFormat *> all = {
         &vopmFormat(),
@@ -552,9 +552,9 @@ const std::vector<const TextFormat *> &TextFormat::allFormats()
     return all;
 }
 
-const TextFormat *TextFormat::getFormatByName(const std::string &name)
+const TextFormat *TextFormats::getFormatByName(const std::string &name)
 {
-    for(const TextFormat *tf : TextFormat::allFormats())
+    for(const TextFormat *tf : allFormats())
         if(name == tf->name())
             return tf;
     return nullptr;

--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -315,6 +315,33 @@ bool GrammaticalTextFormat::parseInstrument(const char *text, FmBank::Instrument
 }
 
 ///
+void CompositeTextFormat::setWriterFormat(const std::shared_ptr<TextFormat> &format)
+{
+    m_writeFormat = format;
+}
+
+void CompositeTextFormat::addReaderFormat(const std::shared_ptr<TextFormat> &format)
+{
+    m_readFormats.push_back(format);
+}
+
+std::string CompositeTextFormat::formatInstrument(const FmBank::Instrument &ins) const
+{
+    TextFormat *tf = m_writeFormat.get();
+    return tf ? tf->formatInstrument(ins) : std::string();
+}
+
+bool CompositeTextFormat::parseInstrument(const char *text, FmBank::Instrument &ins) const
+{
+    for(const std::shared_ptr<TextFormat> &tf : m_readFormats)
+    {
+        if (tf->parseInstrument(text, ins))
+            return true;
+    }
+    return false;
+}
+
+///
 static GrammaticalTextFormat createVopmFormat()
 {
     GrammaticalTextFormat tf;

--- a/src/FileFormats/text_format.h
+++ b/src/FileFormats/text_format.h
@@ -34,37 +34,52 @@ typedef std::unique_ptr<Token> TokenPtr;
 class TextFormat
 {
 public:
-    static const TextFormat &vopmFormat();
-    static const TextFormat &pmdFormat();
-    static const TextFormat &fmpFormat();
-    static const TextFormat &notexFormat();
-    static const TextFormat &nrtdrvFormat();
-    static const TextFormat &mucom88Format();
-
-    static const std::vector<const TextFormat *> &allFormats();
-    static const TextFormat *getFormatByName(const std::string &name);
-
-public:
-    bool isValid() const { return m_valid; }
+    virtual ~TextFormat() {}
 
     const std::string &name() const { return m_name; }
     void setName(const std::string &name) { m_name = name; }
+
+    virtual std::string formatInstrument(const FmBank::Instrument &ins) const = 0;
+    virtual bool parseInstrument(const char *text, FmBank::Instrument &ins) const = 0;
+
+protected:
+    std::string m_name;
+};
+
+///
+namespace TextFormats
+{
+    const TextFormat &vopmFormat();
+    const TextFormat &pmdFormat();
+    const TextFormat &fmpFormat();
+    const TextFormat &notexFormat();
+    const TextFormat &nrtdrvFormat();
+    const TextFormat &mucom88Format();
+
+    const std::vector<const TextFormat *> &allFormats();
+    const TextFormat *getFormatByName(const std::string &name);
+};
+
+///
+class GrammaticalTextFormat : public TextFormat
+{
+public:
+    bool isValid() const { return m_valid; }
 
     //
     void setLineComment(const std::string &com) { m_lineComment = com; }
     void setLineKeepPrefix(const std::string &prefix) { m_lineKeepPrefix = prefix; }
 
     //
-    template <class T> TextFormat &operator<<(const T &token);
-    TextFormat &operator<<(const char *tokenText);
+    template <class T> GrammaticalTextFormat &operator<<(const T &token);
+    GrammaticalTextFormat &operator<<(const char *tokenText);
 
     //
-    std::string formatInstrument(const FmBank::Instrument &ins) const;
-    bool parseInstrument(const char *text, FmBank::Instrument &ins) const;
+    std::string formatInstrument(const FmBank::Instrument &ins) const override;
+    bool parseInstrument(const char *text, FmBank::Instrument &ins) const override;
 
 protected:
     bool m_valid = true;
-    std::string m_name;
     std::string m_lineComment; // a line comment syntax, most often `//` or `;`
     std::string m_lineKeepPrefix; // a prefix of text lines not to discard (`'` in the case of FMP)
     std::vector<TextFormatTokens::TokenPtr> m_tokens;

--- a/src/FileFormats/text_format.h
+++ b/src/FileFormats/text_format.h
@@ -85,4 +85,19 @@ protected:
     std::vector<TextFormatTokens::TokenPtr> m_tokens;
 };
 
+///
+class CompositeTextFormat : public TextFormat
+{
+public:
+    void setWriterFormat(const std::shared_ptr<TextFormat> &format);
+    void addReaderFormat(const std::shared_ptr<TextFormat> &format);
+
+    std::string formatInstrument(const FmBank::Instrument &ins) const override;
+    bool parseInstrument(const char *text, FmBank::Instrument &ins) const override;
+
+private:
+    std::shared_ptr<TextFormat> m_writeFormat;
+    std::vector<std::shared_ptr<TextFormat>> m_readFormats;
+};
+
 #endif

--- a/src/bank_editor.cpp
+++ b/src/bank_editor.cpp
@@ -150,7 +150,7 @@ BankEditor::BankEditor(QWidget *parent) :
 
         QMenu *textconvFormatSubmenu = new QMenu(tr("Select format"), this);
         textconvMenu->addMenu(textconvFormatSubmenu);
-        for(const TextFormat *tf : TextFormat::allFormats())
+        for(const TextFormat *tf : TextFormats::allFormats())
         {
             QString formatName = QString::fromStdString(tf->name());
             QAction *action = textconvFormatSubmenu->addAction(formatName);
@@ -160,7 +160,7 @@ BankEditor::BankEditor(QWidget *parent) :
 
         ui->textconvButton->setPopupMode(QToolButton::InstantPopup);
 
-        setTextconvFormat(*TextFormat::allFormats().front());
+        setTextconvFormat(*TextFormats::allFormats().front());
     }
 
     ui->instruments->installEventFilter(this);
@@ -272,7 +272,7 @@ void BankEditor::loadSettings()
         break;
     }
 
-    if(const TextFormat *tf = TextFormat::getFormatByName(
+    if(const TextFormat *tf = TextFormats::getFormatByName(
            setup.value("text-conversion-format").toString().toStdString()))
         setTextconvFormat(*tf);
 }
@@ -1870,7 +1870,7 @@ void BankEditor::onTextconvPasteTriggered()
 void BankEditor::onTextconvFormatSelected()
 {
     QString currentFormatName = qobject_cast<QAction *>(sender())->data().toString();
-    const TextFormat *currentFormat = TextFormat::getFormatByName(currentFormatName.toStdString());
+    const TextFormat *currentFormat = TextFormats::getFormatByName(currentFormatName.toStdString());
 
     Q_ASSERT(currentFormat);
     if(!currentFormat)


### PR DESCRIPTION
#71 @papiezak

This adds a special kind of format known as composite, which tries a sequence of different subformats until one will match.

As documented, PMD has two subformats. First, I will try the OPM, and second the OPN if that fails.
OPM instruments cannot interpret as OPN, which is not the case of the opposite.
https://pigu-a.github.io/pmddocs/pmdmml.htm#3-1

The commit defines PMD as a composite format.