### PR TITLE
Add GM-only and Needs-measure format capabilities

### DIFF
--- a/src/FileFormats/ffmt_enums.h
+++ b/src/FileFormats/ffmt_enums.h
@@ -58,11 +58,23 @@ enum InstFormats
 
 enum class FormatCaps
 {
+    //! No capabilities, dummy
     FORMAT_CAPS_NOTHING = 0x00,
+    //! Can be opened for editing
     FORMAT_CAPS_OPEN    = 0x01,
+    //! Can be saved
     FORMAT_CAPS_SAVE    = 0x02,
+    //! Can be opened to import data into currently opened bank
     FORMAT_CAPS_IMPORT  = 0x04,
-    FORMAT_CAPS_EVERYTHING = FORMAT_CAPS_OPEN|FORMAT_CAPS_SAVE|FORMAT_CAPS_IMPORT
+    //! On every save the delay measures will be generated
+    FORMAT_CAPS_NEEDS_MEASURE = 0x08,
+    //! Format is able to keep only one bank only
+    FORMAT_CAPS_GM_BANK = 0x10,
+
+    //! Open/Save/Import capabilities
+    FORMAT_CAPS_EVERYTHING = FORMAT_CAPS_OPEN|FORMAT_CAPS_SAVE|FORMAT_CAPS_IMPORT,
+    //! Open/Save/Import capabilities
+    FORMAT_CAPS_EVERYTHING_GM = FORMAT_CAPS_OPEN|FORMAT_CAPS_SAVE|FORMAT_CAPS_IMPORT|FORMAT_CAPS_GM_BANK
 };
 
 /**

--- a/src/FileFormats/ffmt_factory.cpp
+++ b/src/FileFormats/ffmt_factory.cpp
@@ -259,6 +259,28 @@ bool FmBankFormatFactory::isImportOnly(BankFormats format)
     return false;
 }
 
+bool FmBankFormatFactory::hasCaps(BankFormats format, int capsQuery)
+{
+    for(FmBankFormatBase_uptr &p : g_formats)
+    {
+        Q_ASSERT(p.get());//It must be non-null!
+        if(p->formatId() == format)
+            return ((p->formatCaps() & capsQuery) != 0);
+    }
+    return false;
+}
+
+QString FmBankFormatFactory::formatName(BankFormats format)
+{
+    for(FmBankFormatBase_uptr &p : g_formats)
+    {
+        Q_ASSERT(p.get());//It must be non-null!
+        if(p->formatId() == format)
+            return p->formatName();
+    }
+    return "Unknown";
+}
+
 
 
 FfmtErrCode FmBankFormatFactory::OpenBankFile(QString filePath, FmBank &bank, BankFormats *recent)

--- a/src/FileFormats/ffmt_factory.h
+++ b/src/FileFormats/ffmt_factory.h
@@ -48,7 +48,8 @@ public:
      * @return true if this format is instrument import only
      */
     static bool isImportOnly(BankFormats format);
-
+    static bool hasCaps(BankFormats format, int capsQuery);
+    static QString formatName(BankFormats format);
     static FfmtErrCode OpenBankFile(QString filePath, FmBank &bank, BankFormats *recent=0);
     static FfmtErrCode ImportBankFile(QString filePath, FmBank &bank, BankFormats *recent=0);
     static FfmtErrCode SaveBankFile(QString filePath, FmBank &bank, BankFormats dest);

--- a/src/FileFormats/format_m2v_gyb.cpp
+++ b/src/FileFormats/format_m2v_gyb.cpp
@@ -793,7 +793,7 @@ FfmtErrCode M2V_GYB_WRITEv1::saveFile(QString filePath, FmBank &bank)
 
 int M2V_GYB_WRITEv1::formatCaps() const
 {
-    return (int)FormatCaps::FORMAT_CAPS_SAVE;
+    return (int)FormatCaps::FORMAT_CAPS_SAVE|(int)FormatCaps::FORMAT_CAPS_GM_BANK;
 }
 
 QString M2V_GYB_WRITEv1::formatName() const
@@ -823,7 +823,7 @@ FfmtErrCode M2V_GYB_WRITEv2::saveFile(QString filePath, FmBank &bank)
 
 int M2V_GYB_WRITEv2::formatCaps() const
 {
-    return (int)FormatCaps::FORMAT_CAPS_SAVE;
+    return (int)FormatCaps::FORMAT_CAPS_SAVE|(int)FormatCaps::FORMAT_CAPS_GM_BANK;
 }
 
 QString M2V_GYB_WRITEv2::formatName() const

--- a/src/FileFormats/format_saxman_ymx.cpp
+++ b/src/FileFormats/format_saxman_ymx.cpp
@@ -192,7 +192,7 @@ FfmtErrCode Saxman_YMX::saveFile(QString filePath, FmBank &bank)
 
 int Saxman_YMX::formatCaps() const
 {
-    return (int)FormatCaps::FORMAT_CAPS_EVERYTHING;
+    return (int)FormatCaps::FORMAT_CAPS_EVERYTHING_GM;
 }
 
 QString Saxman_YMX::formatName() const

--- a/src/FileFormats/format_wohlstand_opn2.cpp
+++ b/src/FileFormats/format_wohlstand_opn2.cpp
@@ -348,7 +348,7 @@ tryAgain:
 
 int WohlstandOPN2::formatCaps() const
 {
-    return (int)FormatCaps::FORMAT_CAPS_EVERYTHING;
+    return (int)FormatCaps::FORMAT_CAPS_EVERYTHING|(int)FormatCaps::FORMAT_CAPS_NEEDS_MEASURE;
 }
 
 QString WohlstandOPN2::formatName() const

--- a/src/bank_editor.cpp
+++ b/src/bank_editor.cpp
@@ -496,7 +496,23 @@ bool BankEditor::openOrImportFile(QString filePath)
 
 bool BankEditor::saveBankFile(QString filePath, BankFormats format)
 {
-    if(format == BankFormats::FORMAT_WOHLSTAND_OPN2)
+    if(FmBankFormatFactory::hasCaps(format, (int)FormatCaps::FORMAT_CAPS_GM_BANK) &&
+        ((m_bank.Banks_Melodic.size() > 1) || (m_bank.Banks_Percussion.size() > 1))
+    )
+    {
+        int reply = QMessageBox::question(this,
+                                          tr("Save GeneralMIDI bank file"),
+                                          tr("Saving into '%1' format allows you to have "
+                                             "one melodic and one percussion banks only. "
+                                             "All extra banks will be ignored while saving into the file.\n\n"
+                                             "Do you want to continue file saving?")
+                                          .arg(FmBankFormatFactory::formatName(format)),
+                                          QMessageBox::Yes|QMessageBox::Cancel);
+        if(reply != QMessageBox::Yes)
+            return false;
+    }
+
+    if(FmBankFormatFactory::hasCaps(format, (int)FormatCaps::FORMAT_CAPS_NEEDS_MEASURE))
     {
         if(!m_measurer->doMeasurement(m_bank, m_bankBackup))
             return false;//Measurement was cancelled


### PR DESCRIPTION
A backport of some capabilities from OPL3 Bank Editor.
The flags were set on file formats where appropriate.
