### PR TITLE
TextFormat: support FMP4 format as well as existing FMP7 format

### DIFF
--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -264,6 +264,11 @@ bool GrammaticalTextFormat::parseInstrument(const char *text, FmBank::Instrument
                 break;
             }
             const MetaParameter *mp = static_cast<const Val &>(*token).parameter();
+            if (!mp)
+            {
+                success = false;
+                break;
+            }
             mp->set(ins, mp->clamp(value));
             break;
         }
@@ -468,11 +473,11 @@ static CompositeTextFormat createPmdFormat()
     return tf;
 }
 
-static GrammaticalTextFormat createFmpFormat()
+static GrammaticalTextFormat createFmp7FAFormat()
 {
     GrammaticalTextFormat tf;
 
-    tf.setName("FMP");
+    tf.setName("FMP7FA");
     tf.setLineKeepPrefix("'");
 
     using namespace TextFormatTokens;
@@ -488,12 +493,91 @@ static GrammaticalTextFormat createFmpFormat()
            << "," << Val("d2r", op) << "," << Val("rr", op)
            << "," << Val("d1l", op) << "," << Val("tl", op)
            << "," << Val("rs", op) << "," << Val("mul", op)
+           << "," << Val("dt", op) << "," << Val("am", op) << "\n";
+    }
+
+    tf << "'" << "@" << " " << Val("alg") << "," << Val("fb") << "\n";
+
+    return tf;
+}
+
+static GrammaticalTextFormat createFmp7FFormat()
+{
+    GrammaticalTextFormat tf;
+
+    tf.setName("FMP7F");
+    tf.setLineKeepPrefix("'");
+
+    using namespace TextFormatTokens;
+
+    // permissive parsing on this line
+    tf << "'" << "@" << " " << AlphaNumString("F") << " " << AlphaNumString("0") << "\n";
+
+    for(int o = 0; o < 4; ++o)
+    {
+        int op = MP_Operator1 + o;
+        tf << "'" << "@"
+           << " " << Val("ar", op) << "," << Val("d1r", op)
+           << "," << Val("d2r", op) << "," << Val("rr", op)
+           << "," << Val("d1l", op) << "," << Val("tl", op)
+           << "," << Val("rs", op) << "," << Val("mul", op)
+           << "," << Val("dt", op) << "\n";
+    }
+
+    tf << "'" << "@" << " " << Val("alg") << "," << Val("fb") << "\n";
+
+    return tf;
+}
+
+static GrammaticalTextFormat createFmp4Format()
+{
+    GrammaticalTextFormat tf;
+
+    tf.setName("FMP4");
+    tf.setLineKeepPrefix("'");
+
+    using namespace TextFormatTokens;
+
+    // permissive parsing on this line
+    tf << "'" << "@" << " " << AlphaNumString("0") << "\n";
+
+    for(int o = 0; o < 4; ++o)
+    {
+        int op = MP_Operator1 + o;
+        tf << "'" << "@"
+           << " " << Val("ar", op) << "," << Val("d1r", op)
+           << "," << Val("d2r", op) << "," << Val("rr", op)
+           << "," << Val("d1l", op) << "," << Val("tl", op)
+           << "," << Val("rs", op) << "," << Val("mul", op)
            << "," << Val("dt", op) << Conditional(TokenSharedPtr(new Symbol(",")),
-                                                  TokenList{} << Whitespace(" ") << Val("am", op),
+                                                  TokenList{} << Whitespace(" ") << Val("dt2", op),
                                                   TokenList{}) << "\n";
     }
 
     tf << "'" << "@" << " " << Val("alg") << "," << Val("fb") << "\n";
+
+    return tf;
+}
+
+static CompositeTextFormat createFmpFormat()
+{
+    CompositeTextFormat tf;
+    tf.setName("FMP");
+
+    std::shared_ptr<GrammaticalTextFormat> tfFmp7FA(
+        new GrammaticalTextFormat(createFmp7FAFormat()));
+    std::shared_ptr<GrammaticalTextFormat> tfFmp7F(
+        new GrammaticalTextFormat(createFmp7FFormat()));
+    std::shared_ptr<GrammaticalTextFormat> tfFmp4(
+        new GrammaticalTextFormat(createFmp4Format()));
+
+    // always write it as FMP7FA
+    tf.setWriterFormat(tfFmp7FA);
+
+    // try FMP7 (FA -> F) -> FMP4
+    tf.addReaderFormat(tfFmp7FA);
+    tf.addReaderFormat(tfFmp7F);
+    tf.addReaderFormat(tfFmp4);
 
     return tf;
 }
@@ -630,7 +714,7 @@ const TextFormat &TextFormats::pmdFormat()
 
 const TextFormat &TextFormats::fmpFormat()
 {
-    static GrammaticalTextFormat tf = createFmpFormat();
+    static CompositeTextFormat tf = createFmpFormat();
     return tf;
 }
 

--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -488,7 +488,9 @@ static GrammaticalTextFormat createFmpFormat()
            << "," << Val("d2r", op) << "," << Val("rr", op)
            << "," << Val("d1l", op) << "," << Val("tl", op)
            << "," << Val("rs", op) << "," << Val("mul", op)
-           << "," << Val("dt", op) << "," << Val("am", op) << "\n";
+           << "," << Val("dt", op) << Conditional(TokenSharedPtr(new Symbol(",")),
+                                                  TokenList{} << Whitespace(" ") << Val("am", op),
+                                                  TokenList{}) << "\n";
     }
 
     tf << "'" << "@" << " " << Val("alg") << "," << Val("fb") << "\n";

--- a/src/FileFormats/text_format.cpp
+++ b/src/FileFormats/text_format.cpp
@@ -483,7 +483,7 @@ static GrammaticalTextFormat createFmp7FAFormat()
     using namespace TextFormatTokens;
 
     // permissive parsing on this line
-    tf << "'" << "@" << " " << AlphaNumString("FA") << " " << AlphaNumString("0") << "\n";
+    tf << "'" << "@" << " " << Symbol("FA") << " " << AlphaNumString("0") << "\n";
 
     for(int o = 0; o < 4; ++o)
     {
@@ -511,7 +511,7 @@ static GrammaticalTextFormat createFmp7FFormat()
     using namespace TextFormatTokens;
 
     // permissive parsing on this line
-    tf << "'" << "@" << " " << AlphaNumString("F") << " " << AlphaNumString("0") << "\n";
+    tf << "'" << "@" << " " << Symbol("F") << " " << AlphaNumString("0") << "\n";
 
     for(int o = 0; o < 4; ++o)
     {
@@ -549,9 +549,7 @@ static GrammaticalTextFormat createFmp4Format()
            << "," << Val("d2r", op) << "," << Val("rr", op)
            << "," << Val("d1l", op) << "," << Val("tl", op)
            << "," << Val("rs", op) << "," << Val("mul", op)
-           << "," << Val("dt", op) << Conditional(TokenSharedPtr(new Symbol(",")),
-                                                  TokenList{} << Whitespace(" ") << Val("dt2", op),
-                                                  TokenList{}) << "\n";
+           << "," << Val("dt", op) << "\n";
     }
 
     tf << "'" << "@" << " " << Val("alg") << "," << Val("fb") << "\n";


### PR DESCRIPTION
context: https://github.com/Wohlstand/OPN2BankEditor/issues/81 / https://github.com/Wohlstand/OPN2BankEditor/pull/82

In FMP distribution from 199x, there was a default template bank
definition file (`88NEIRO.TPI`) whose format was like this:

```
"Harpsichord
'@ 0
   AR DR SR RR SL TL KS ML DT
'@ 31,12, 4,10, 1,32, 0,12, 0
'@ 31, 2, 4, 6,15,57, 3,15, 1
'@ 31,12, 4, 6, 0,30, 0, 1, 0
'@ 31, 5, 7, 7, 2, 0, 2, 3, 4
'@ 2,7
```

On the other hand, this is what we see from "Copy to FMP":

```
'@ FA 0
'@   0,  0,  0,  0,  0,  0,  0,  0,  0,   0
'@   0,  0,  0,  0,  0,  0,  0,  0,  0,   0
'@   0,  0,  0,  0,  0,  0,  0,  0,  0,   0
'@   0,  0,  0,  0,  0,  0,  0,  0,  0,   0
'@   0,  0
```

There are some notable differences, but so far what I find annoying is
that the last parameter (AM/DT2) was optional in the original format,
while it was mandatory without this fix.